### PR TITLE
Extensions proposal (not about making Standard "configurable")

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ and its rules will be included when using `standard`.
 - [React](https://www.npmjs.com/package/standard-extension-react)
 - [AVA](https://www.npmjs.com/package/standard-extension-ava)
 
-
 ## FAQ
 
 ### Why would I use JavaScript Standard Style?

--- a/README.md
+++ b/README.md
@@ -252,6 +252,28 @@ Both WebStorm and PhpStorm can be [configured for Standard Style][webstorm-2].
 [webstorm-1]: https://www.jetbrains.com/webstorm/
 [webstorm-2]: https://github.com/feross/standard/blob/master/docs/webstorm.md
 
+### Extensions
+
+Extensions are a way to add official Standard Style linting rules for specific libraries.
+
+#### Usage
+
+Simply install each extension:
+
+```console
+$ npm i --save-dev standard-extension-<name>
+```
+
+and its rules will be included when using `standard`.
+
+#### Available extensions
+
+> **Note: This is a curated, [white-list](https://en.wikipedia.org/wiki/Whitelist) set of extensions.**
+
+- [React](https://www.npmjs.com/package/standard-extension-react)
+- [AVA](https://www.npmjs.com/package/standard-extension-ava)
+
+
 ## FAQ
 
 ### Why would I use JavaScript Standard Style?


### PR DESCRIPTION
# Extensions proposal

## Background
In the past we had a React and a JSX plugin. To avoid bloat, these were removed from standard. Were they dependencies? I've recently [suggested an AVA plugin](https://github.com/feross/eslint-config-standard/pull/57) and it was refused to avoid bloat.

Avoiding bloat is great. Yet, as it is, feross/standard is not extensible. So, in order to use feross/standard and probably all other front-ends for Flet/standard-engine combined with some other set of rules, like for React or AVA, one would use ESLint directly, extending on feross/eslint-config-standard.

## Use
What if all one had to do, is to install standard and some extensions and it would just work?

```console
$ npm --save-dev install standard standard-extension-react standard-extension-ava
```

Zero configuration. Just like that.

## Principals

### No duplicate rules

There would have to be an assertion in standard-engine that none of the rules from plugins override any rule from eslint-config-standard and perhaps also that they do not override any of each other's rules. In short, no overrides at all. No duplicate rules.

### Curation

Now, not just any package with the name *standard-extension-** would work. The extensions will be curated/white-listed in feross/standard and possibly owned by the same team. Or perhaps we should make it an organization (but that's a tangent).

## Going forward

Please provide feedback:

* Do the maintainers of standard and standard-engine find the concept of extensions agreeable?
  * Do you agree with the suggested form of usage?
  * Do you agree with the principals laid out?

## Candidate extensions

### typescript

Would be based off of the existing [eslint-config-standard-with-typescript](https://github.com/standard/eslint-config-standard-with-typescript).

### end-project

A project that is not imported and used as a library / package in another project.

- [@typescript-eslint/no-unnecessary-condition](https://github.com/typescript-eslint/typescript-eslint/blob/v2.29.0/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md)
  The only issue with enabling this in core is described [here](https://github.com/standard/eslint-config-standard-with-typescript/pull/177#issuecomment-558027535).

### react

Rules that are specific to [React](https://reactjs.org/). Perhaps includes JSX? I'm not familiar with the ecosystem.