### PR TITLE
Adding valid example for no-unsafe-negation

### DIFF
--- a/docs/RULES-en.md
+++ b/docs/RULES-en.md
@@ -1073,6 +1073,7 @@ your code.
 
   ```js
   if (!key in obj) {}       // ✗ avoid
+  if (!(key in obj)) {}     // ✓ ok
   ```
 
 * **Avoid unnecessary use of `.call()` and `.apply()`.**


### PR DESCRIPTION
It wasn't quite clear what's the reason behind no-unsafe-negation, as the "avoid" statement wouldn't make much sense anyway.