### PR TITLE
Update dependecy of eslint-config-standard-jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "eslint": "~3.19.0",
     "eslint-config-standard": "10.2.1",
-    "eslint-config-standard-jsx": "4.0.1",
+    "eslint-config-standard-jsx": "~4.0.2",
     "eslint-plugin-import": "~2.2.0",
     "eslint-plugin-node": "~4.2.2",
     "eslint-plugin-promise": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "eslint": "~3.19.0",
     "eslint-config-standard": "10.2.1",
-    "eslint-config-standard-jsx": "~4.0.2",
+    "eslint-config-standard-jsx": "4.0.2",
     "eslint-plugin-import": "~2.2.0",
     "eslint-plugin-node": "~4.2.2",
     "eslint-plugin-promise": "~3.5.0",


### PR DESCRIPTION
I've been having issues with a deprecation warning of `react/jsx-space-before-closing` and `eslint-config-standard-jsx` package, that are solved on `v4.0.2` by this commit standard/eslint-config-standard-jsx@c13637e.

I would like to reference this issue bcomnes/sublime-standard-format#54 too, becouse this change fixes it for me.