### PR TITLE
What you might do if you're cleverer?

### DIFF
--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -156,7 +156,8 @@ $ standard "src/util/**/*.js" "test/**/*.js"
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "pretest": "standard",
+      "test": "node my-tests.js"
     }
   }
   ```

--- a/docs/README-esla.md
+++ b/docs/README-esla.md
@@ -153,7 +153,8 @@ $ standard "src/util/**/*.js" "test/**/*.js"
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "pretest": "standard",
+      "test": "node my-tests.js"
     }
   }
   ```

--- a/docs/README-iteu.md
+++ b/docs/README-iteu.md
@@ -154,7 +154,8 @@ $ standard "src/util/**/*.js" "test/**/*.js"
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "pretest": "standard",
+      "test": "node my-tests.js"
     }
   }
 

--- a/docs/README-kokr.md
+++ b/docs/README-kokr.md
@@ -145,7 +145,8 @@ $ standard "src/util/**/*.js" "test/**/*.js"
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "pretest": "standard",
+      "test": "node my-tests.js"
     }
   }
   ```

--- a/docs/README-ptbr.md
+++ b/docs/README-ptbr.md
@@ -145,7 +145,8 @@ $ standard "src/util/**/*.js" "test/**/*.js"
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "pretest": "standard",
+      "test": "node my-tests.js"
     }
   }
   ```

--- a/docs/README-zhcn.md
+++ b/docs/README-zhcn.md
@@ -142,7 +142,8 @@ $ standard "src/util/**/*.js" "test/**/*.js"
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "pretest": "standard",
+      "test": "node my-tests.js"
     }
   }
   ```

--- a/docs/README-zhtw.md
+++ b/docs/README-zhtw.md
@@ -137,7 +137,8 @@ $ standard "src/util/**/*.js" "test/**/*.js"
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "pretest": "standard",
+      "test": "node my-tests.js"
     }
   }
   ```


### PR DESCRIPTION
Moving standard to the "pretest" script accomplishes the same goal of having standard automatically run before "test" is run but also allows you to run it separately, e.g. `npm run pretest`.