### PR TITLE
fix error example 修复错误的示例

### DIFF
--- a/docs/RULES-zhcn.md
+++ b/docs/RULES-zhcn.md
@@ -130,10 +130,12 @@
 
   ```js
   // ✗ avoid
-  if (condition) {
+  if (condition) 
+  {
     // ...
   }
-  else {
+  else 
+  {
     // ...
   }
   ```
@@ -200,6 +202,7 @@
   ```js
   // ✗ avoid
   var value = 'hello world'
+  ```
 
 
   console.log(value)


### PR DESCRIPTION
fix the error example on the rule 「eslint: brace-style」