### PR TITLE
Fix broken relative links in readme.md

### DIFF
--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -16,13 +16,13 @@
 <h4 align="center">One JavaScript Style to Rule Them All</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="https://github.com/standard/standard/blob/master/docs/README-en.md">English</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-esla.md
+++ b/docs/README-esla.md
@@ -16,13 +16,13 @@
 <h4 align="center">Una guía de estilos JavaScript para gobernarlos a todos</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="https://github.com/standard/standard/blob/master/docs/README-en.md">English</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-iteu.md
+++ b/docs/README-iteu.md
@@ -16,13 +16,13 @@
 <h4 align="center">Un solo Stile JavaScript per domarli tutti</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="https://github.com/standard/standard/blob/master/docs/README-en.md">English</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-kokr.md
+++ b/docs/README-kokr.md
@@ -16,13 +16,13 @@
 <h4 align="center">One JavaScript Style to Rule Them All</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="https://github.com/standard/standard/blob/master/docs/README-en.md">English</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-ptbr.md
+++ b/docs/README-ptbr.md
@@ -16,13 +16,13 @@
 <h4 align="center">Um Guia de Estilo JavaScript para a todos governar</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="https://github.com/standard/standard/blob/master/docs/README-en.md">English</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-zhcn.md
+++ b/docs/README-zhcn.md
@@ -16,13 +16,13 @@
 <h4 align="center">One JavaScript Style to Rule Them All</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="https://github.com/standard/standard/blob/master/docs/README-en.md">English</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-zhtw.md
+++ b/docs/README-zhtw.md
@@ -16,13 +16,13 @@
 <h4 align="center">統一 JavaScript，只需一種樣式</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="https://github.com/standard/standard/blob/master/docs/README-en.md">English</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="https://github.com/standard/standard/blob/master/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>


### PR DESCRIPTION
Links to translations are broken in readme.md. This pull request fix them by replacing relative path with absolute one.

Would fix issue https://github.com/standard/standard/issues/966