### PR TITLE
Fixing links in README and RULES files

### DIFF
--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -16,13 +16,13 @@
 <h4 align="center">One JavaScript Style to Rule Them All</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-en.md">English</a> •
+  <a href="/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-esla.md
+++ b/docs/README-esla.md
@@ -16,13 +16,13 @@
 <h4 align="center">Una guía de estilos JavaScript para gobernarlos a todos</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-en.md">English</a> •
+  <a href="/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-iteu.md
+++ b/docs/README-iteu.md
@@ -16,13 +16,13 @@
 <h4 align="center">Un solo Stile JavaScript per domarli tutti</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-en.md">English</a> •
+  <a href="/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-kokr.md
+++ b/docs/README-kokr.md
@@ -16,13 +16,13 @@
 <h4 align="center">One JavaScript Style to Rule Them All</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-en.md">English</a> •
+  <a href="/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-ptbr.md
+++ b/docs/README-ptbr.md
@@ -16,13 +16,13 @@
 <h4 align="center">Um Guia de Estilo JavaScript para a todos governar</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-en.md">English</a> •
+  <a href="/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-zhcn.md
+++ b/docs/README-zhcn.md
@@ -16,13 +16,13 @@
 <h4 align="center">One JavaScript Style to Rule Them All</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-en.md">English</a> •
+  <a href="/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/README-zhtw.md
+++ b/docs/README-zhtw.md
@@ -16,13 +16,13 @@
 <h4 align="center">統一 JavaScript，只需一種樣式</h4>
 
 <p align="center">
-  <a href="README-en.md">English</a> •
-  <a href="README-esla.md">Español (Latinoamérica)</a> •
-  <a href="README-iteu.md">Italiano (Italian)</a> •
-  <a href="README-kokr.md">한국어 (Korean)</a> •
-  <a href="README-ptbr.md">Português (Brasil)</a> •
-  <a href="README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-en.md">English</a> •
+  <a href="/docs/README-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/README-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 <br>

--- a/docs/RULES-en.md
+++ b/docs/RULES-en.md
@@ -1,13 +1,13 @@
 # JavaScript Standard Style
 
 <p align="center">
-  <a href="RULES-en.md">English</a> •
-  <a href="RULES-esla.md">Español (Latinoamérica)</a> •
-  <a href="RULES-iteu.md">Italiano (Italian)</a> •
-  <a href="RULES-kokr.md">한국어 (Korean)</a> •
-  <a href="RULES-ptbr.md">Português (Brasil)</a> •
-  <a href="RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/RULES-en.md">English</a> •
+  <a href="/docs/RULES-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/RULES-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/RULES-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/RULES-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 [![js-standard-style](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)

--- a/docs/RULES-esla.md
+++ b/docs/RULES-esla.md
@@ -1,13 +1,13 @@
 # JavaScript Standard Style
 
 <p align="center">
-  <a href="RULES-en.md">English</a> •
-  <a href="RULES-esla.md">Español (Latinoamérica)</a> •
-  <a href="RULES-iteu.md">Italiano (Italian)</a> •
-  <a href="RULES-kokr.md">한국어 (Korean)</a> •
-  <a href="RULES-ptbr.md">Português (Brasil)</a> •
-  <a href="RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/RULES-en.md">English</a> •
+  <a href="/docs/RULES-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/RULES-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/RULES-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/RULES-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 [![js-standard-style](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)

--- a/docs/RULES-iteu.md
+++ b/docs/RULES-iteu.md
@@ -1,13 +1,13 @@
 # JavaScript Standard Style
 
 <p align="center">
-  <a href="RULES-en.md">English</a> •
-  <a href="RULES-esla.md">Español (Latinoamérica)</a> •
-  <a href="RULES-iteu.md">Italiano (Italian)</a> •
-  <a href="RULES-kokr.md">한국어 (Korean)</a> •
-  <a href="RULES-ptbr.md">Português (Brasil)</a> •
-  <a href="RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/RULES-en.md">English</a> •
+  <a href="/docs/RULES-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/RULES-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/RULES-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/RULES-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 [![js-standard-style](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)

--- a/docs/RULES-kokr.md
+++ b/docs/RULES-kokr.md
@@ -1,13 +1,13 @@
 # JavaScript Standard Style
 
 <p align="center">
-  <a href="RULES-en.md">English</a> •
-  <a href="RULES-esla.md">Español (Latinoamérica)</a> •
-  <a href="RULES-iteu.md">Italiano (Italian)</a> •
-  <a href="RULES-kokr.md">한국어 (Korean)</a> •
-  <a href="RULES-ptbr.md">Português (Brasil)</a> •
-  <a href="RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/RULES-en.md">English</a> •
+  <a href="/docs/RULES-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/RULES-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/RULES-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/RULES-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 [![js-standard-style](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)

--- a/docs/RULES-ptbr.md
+++ b/docs/RULES-ptbr.md
@@ -1,13 +1,13 @@
 # JavaScript Standard Style
 
 <p align="center">
-  <a href="RULES-en.md">English</a> •
-  <a href="RULES-esla.md">Español (Latinoamérica)</a> •
-  <a href="RULES-iteu.md">Italiano (Italian)</a> •
-  <a href="RULES-kokr.md">한국어 (Korean)</a> •
-  <a href="RULES-ptbr.md">Português (Brasil)</a> •
-  <a href="RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/RULES-en.md">English</a> •
+  <a href="/docs/RULES-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/RULES-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/RULES-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/RULES-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 [![js-standard-style](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)

--- a/docs/RULES-zhcn.md
+++ b/docs/RULES-zhcn.md
@@ -1,13 +1,13 @@
 # JavaScript Standard Style
 
 <p align="center">
-  <a href="RULES-en.md">English</a> •
-  <a href="RULES-esla.md">Español (Latinoamérica)</a> •
-  <a href="RULES-iteu.md">Italiano (Italian)</a> •
-  <a href="RULES-kokr.md">한국어 (Korean)</a> •
-  <a href="RULES-ptbr.md">Português (Brasil)</a> •
-  <a href="RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/RULES-en.md">English</a> •
+  <a href="/docs/RULES-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/RULES-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/RULES-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/RULES-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 [![js-standard-style](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)

--- a/docs/RULES-zhtw.md
+++ b/docs/RULES-zhtw.md
@@ -1,13 +1,13 @@
 # JavaScript Standard Style
 
 <p align="center">
-  <a href="RULES-en.md">English</a> •
-  <a href="RULES-esla.md">Español (Latinoamérica)</a> •
-  <a href="RULES-iteu.md">Italiano (Italian)</a> •
-  <a href="RULES-kokr.md">한국어 (Korean)</a> •
-  <a href="RULES-ptbr.md">Português (Brasil)</a> •
-  <a href="RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/RULES-en.md">English</a> •
+  <a href="/docs/RULES-esla.md">Español (Latinoamérica)</a> •
+  <a href="/docs/RULES-iteu.md">Italiano (Italian)</a> •
+  <a href="/docs/RULES-kokr.md">한국어 (Korean)</a> •
+  <a href="/docs/RULES-ptbr.md">Português (Brasil)</a> •
+  <a href="/docs/RULES-zhcn.md">简体中文 (Simplified Chinese)</a> •
+  <a href="/docs/RULES-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
 </p>
 
 [![js-standard-style](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)


### PR DESCRIPTION
The links in the main README file for the other languages are broken (#1002). Updating the links in all the README and RULES files to the absolute path.