### PR TITLE
update to eslint 4 in preparation for standard@11.0.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 11.0.0 - 2017-12-11
+
+This release has no new rules, but it does update to the latest version of `eslint`, which has some significant changes to exisitng rules. Most updates are to make rules more strict.
+
+Thankfully, most will just need to run `standard --fix` to update their code to be compliant.
+
+eslint 4:
+  - Bumped to 4.13.0.
+  - The `indent` rule is more strict.
+  - The `padded-blocks` rule is more strict.
+  - The `space-before-function-paren` rule is more strict.
+  - The `no-multi-spaces` rule is more strict.
+  - Minor improvements to
+   - `no-extra-parens`,
+   - `no-unexpected-multiline`,
+   - `no-regex-spaces`, and
+   - `space-unary-ops`
+
+eslint-plugin-import:
+  - Bumped to 2.8.0.
+  - Updated for eslint 4.0 compatibility.
+  - Various small bug fixes included related to `import/*` rules.
+
+eslint-plugin-node:
+  - The `no-deprecated-api` rule updated to with node 8 support and better node 6 support.
+
+ - eslint-plugin-promise:
+  - Bumped to 3.6.0.
+
+eslint-plugin-react:
+  - Bumped to 5.0.0
+  - Fix jsx-indent crash
+  - Fix jsx-indent indentation calculation with nested JSX
+  - jsx-no-undef will not check the global scope by default.
+  - Fix jsx-curly-spacing newline with object literals bug
+  - Fix jsx-curly-spacing schema incompatibility with ESLint 4.2.0
+  - Fix alignment bug in jsx-indent
+
+
 ## 10.0.3 - 2017-08-06
 
 - Internal changes (incremented dependency versions)

--- a/package.json
+++ b/package.json
@@ -12,24 +12,24 @@
     "url": "https://github.com/standard/standard/issues"
   },
   "dependencies": {
-    "eslint": "~3.19.0",
-    "eslint-config-standard": "10.2.1",
+    "eslint": "~4.13.0",
+    "eslint-config-standard": "11.0.0-beta.0",
     "eslint-config-standard-jsx": "4.0.2",
-    "eslint-plugin-import": "~2.2.0",
-    "eslint-plugin-node": "~4.2.2",
-    "eslint-plugin-promise": "~3.5.0",
-    "eslint-plugin-react": "~6.10.0",
+    "eslint-plugin-import": "~2.8.0",
+    "eslint-plugin-node": "~5.2.1",
+    "eslint-plugin-promise": "~3.6.0",
+    "eslint-plugin-react": "~7.5.1",
     "eslint-plugin-standard": "~3.0.1",
-    "standard-engine": "~7.0.0"
+    "standard-engine": "~7.2.0"
   },
   "devDependencies": {
-    "babel-eslint": "^7.0.0",
+    "babel-eslint": "^8.0.3",
     "cross-spawn": "^5.0.1",
     "eslint-index": "^1.3.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "run-parallel-limit": "^1.0.3",
-    "standard-packages": "^3.1.9",
+    "standard-packages": "^3.2.11",
     "tape": "^4.6.0"
   },
   "engines": {

--- a/test/clone.js
+++ b/test/clone.js
@@ -101,8 +101,35 @@ test('test github repos that use `standard`', function (t) {
           if (pkg.args) args.push.apply(args, pkg.args)
           spawn(STANDARD, args, { cwd: folder }, function (err) {
             var str = name + ' (' + pkg.repo + ')'
-            if (err) { t.fail(str) } else { t.pass(str) }
+            if (err) {
+              if (err.message.indexOf('(indent)') || err.message.indexOf('(no-multi-spaces)') || err.message.indexOf('(space-unary-ops)')) {
+                t.comment('Attempting to fix eslint breaking changes for ' + str)
+                return runStandardFix(cb)
+              } else {
+                t.fail(str)
+              }
+            } else {
+              t.pass(str)
+            }
             cb(null)
+          })
+        }
+
+        function runStandardFix (cb) {
+          var args = [ '--fix', '--verbose' ]
+          if (pkg.args) args.push.apply(args, pkg.args)
+          spawn(STANDARD, args, { cwd: folder }, function (err) {
+            var str = name + ' (' + pkg.repo + ')  **with --fix'
+            if (err) { t.fail(str) } else { t.pass(str) }
+            runGitReset(cb)
+          })
+        }
+
+        function runGitReset (cb) {
+          var args = [ 'reset', '--hard' ]
+          spawn(GIT, args, { cwd: folder }, function (err) {
+            if (err) err.message += ' (git reset) (' + name + ')'
+            cb(err)
           })
         }
       })


### PR DESCRIPTION
- update to eslint 4
- update other dependencies
- also attempt to --fix repos with eslint 4 breaking changes

Hi folks!

This PR updated eslint and plugin/config dependencies to their latest versions. The idea is to release this as `standard@11.0.0-beta.0` since some existing eslint rules have gotten more strict. It will also be nice to update to eslint@4 to help folks who are running into various bugs/compatibility issues.

In order to get this out without a lot of hassle, we will not be including any new or modified rules in this major version. This does set the stage nicely for the next version though! :)

Also I included an update to `clone.js` that attempts to `--fix` repositories that have breaking changes related to eslint@4 updates. There are 23/235 (~10%) repositories that break with eslint@4, but they are `--fixed` successfully.


@feross @bcomnes @LinusU 