### PR TITLE
Exclude typescript from no-undef checking

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,3 +1,10 @@
 {
-  "extends": ["standard", "standard-jsx"]
+  "extends": ["standard", "standard-jsx"],
+  "overrides": {
+    "files": ["**/*.ts", "**/*.tsx"],
+    "parser": "typescript-eslint-parser",
+    "rules": {
+      "no-undef": "off"
+    }
+  }
 }


### PR DESCRIPTION
Fix for https://github.com/standard/standard/issues/1099

The solution is introduced in here https://github.com/eslint/typescript-eslint-parser/issues/416#issuecomment-363115171

`ts` means typescript and `tsx` means typescript with react

Tested with my project and it successfully exclude no-undef check for typescript only

![image](https://user-images.githubusercontent.com/1476974/38001999-390f1f4a-3273-11e8-84d5-d8aa78329d3d.png)

