### PR TITLE
Exclude typescript from no-undef checking

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["standard", "standard-jsx"]
+  "extends": ["standard", "standard-jsx"],
+  "overrides": {
+    "files": ["*.ts", "*.tsx"],
+    "rules": {
+      "no-undef": "off"
+    }
+  }
 }


### PR DESCRIPTION
Fix for https://github.com/standard/standard/issues/1099

It's a [known issue](https://github.com/eslint/typescript-eslint-parser#known-issues) in `typescript-eslint-parser`

The solution is based on [here](https://github.com/eslint/typescript-eslint-parser/issues/416#issuecomment-363115171)
(Note: `**.*.ts` and `**.*.tsx` do not seems to work but `*.ts` and `*.tsx` work)

`ts` means typescript and `tsx` means typescript with react

Tested with my project and it successfully exclude no-undef check for typescript only

Before

![image](https://user-images.githubusercontent.com/1476974/38003392-b0e781f4-327a-11e8-9378-ce5cdbb7fd11.png)

After

![image](https://user-images.githubusercontent.com/1476974/38003444-e6b2f0c0-327a-11e8-8299-33aed433f977.png)

