### PR TITLE
eslint@5.0.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/standard/standard/issues"
   },
   "dependencies": {
-    "eslint": "~4.19.0",
+    "eslint": "^5.0.0-alpha.2",
     "eslint-config-standard": "11.0.0",
     "eslint-config-standard-jsx": "5.0.0",
     "eslint-plugin-import": "~2.9.0",


### PR DESCRIPTION
Let's use the latest ESLint on `master` to start playing with it. We'll release `standard@12` once it's stable.

🌟