### PR TITLE
npmignore for smaller install size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,13 @@
+.editorconfig
+.github/
 .npmignore
+.travis.yml
 badge.png
 badge.svg
 CONTRIBUTING.md
+docs/
 docs/logos/
+SECURITY.md
 sticker.png
 sticker.svg
 test/


### PR DESCRIPTION
Smaller install size.

Before:

package size:  127.1 kB                                
unpacked size: 470.1 kB 

After:

package size:  30.9 kB                                 
unpacked size: 105.6 kB