### PR TITLE
eslint@5.0.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/standard/standard/issues"
   },
   "dependencies": {
-    "eslint": "^5.0.0-alpha.2",
+    "eslint": "^5.0.0-rc.0",
     "eslint-config-standard": "standard/eslint-config-standard",
     "eslint-config-standard-jsx": "standard/eslint-config-standard-jsx",
     "eslint-plugin-import": "~2.11.0",


### PR DESCRIPTION
This upgrades eslint to get support for React's new fragment syntax (`<>`/`</>`) and closes #1146.

See also: https://github.com/eslint/eslint/issues/9662