### PR TITLE
moved `babel-eslint` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "eslint-plugin-promise": "~3.8.0",
     "eslint-plugin-react": "~7.7.0",
     "eslint-plugin-standard": "~3.1.0",
+    "babel-eslint": "^8.0.3",
     "standard-engine": "~9.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^8.0.3",
     "cross-spawn": "^6.0.3",
     "eslint-index": "^1.3.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
`babel-eslint` is now an explicit dependency as opposed only a devDependency like it used to be. Without this change `npm install -g standard` will not work out of the box without also installing `npm install -g babel-eslint`

github issue ref: https://github.com/standard/standard/issues/1166

**steps to reproduce error**

`npm uninstall -g standard babel-eslint`
`npm install -g standard`
`standard`
`...index.js:0:0: Cannot find module 'babel-eslint'`

**steps to try out fix**

`npm uninstall -g standard babel-eslint`
`npm install -g talmobi/standard#master`
`standard`
`.../Users/mollie/work/TICKETPLAT-fe-admin/src/components/templates/AncillaryTickets/index.js:95:16: There should be no spaces inside this paren.`