### PR TITLE
Silently pass in node 4

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-if (process.version.match(/v(\d+)\./)[1] < 4) {
-  console.error('standard: Node v4 or greater is required. `standard` did not run.')
+if (process.version.match(/v(\d+)\./)[1] < 6) {
+  console.error('standard: Node 6 or greater is required. `standard` did not run.')
 } else {
   var opts = require('../options')
   require('standard-engine').cli(opts)


### PR DESCRIPTION
Since [ESLint 5 no longer support node 4](https://eslint.org/docs/user-guide/migrating-to-5.0.0#-nodejs-4-is-no-longer-supported), standard should silently pass in node 4.