### PR TITLE
Bump eslint to 5.6.0 (compat with react-scripts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/standard/standard/issues"
   },
   "dependencies": {
-    "eslint": "~5.4.0",
+    "eslint": "~5.6.0",
     "eslint-config-standard": "12.0.0",
     "eslint-config-standard-jsx": "6.0.2",
     "eslint-plugin-import": "~2.14.0",


### PR DESCRIPTION
This minor version bump of eslint is for compatability with react-scripts@2.x which
insists on this version of eslint on startup.

This change will allow folks to continue using standard in conjunction with new react-scripts
releases without issue.