### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:alpine AS builder
+WORKDIR /srv/app
+COPY package.json package.json
+COPY index.js index.js
+COPY options.js options.js
+COPY bin bin
+COPY eslintrc.json eslintrc.json
+RUN npm pack && mv *.tgz standard.tgz
+
+FROM node:alpine
+COPY --from=builder /srv/app/standard.tgz /
+RUN npm i -g standard.tgz && rm standard.tgz
+CMD [ "standard" ]


### PR DESCRIPTION
for autobuild on docker hub. Usage example:
`docker run --rm -i nitra/standard standard --fix "index.js"`

