### PR TITLE
Add a disambiguating "standardjs" bin alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "name": "Feross Aboukhadijeh",
     "url": "https://feross.org/"
   },
-  "bin": "./bin/cmd.js",
+  "bin": {
+    "standard": "./bin/cmd.js",
+    "standardjs": "./bin/cmd.js"
+  },
   "bugs": {
     "url": "https://github.com/standard/standard/issues"
   },


### PR DESCRIPTION
Because there are now "standard"-branded opinionated linters being 
written for other languages, it seems smart to give people who use both
a way to disambiguate between the two by running `standardrb`, 
`standardjs`, etc. explicitly.

Someday, it'd be really neat if a meta `standard` bin could roll-up 
linting for multiple languages in a single project in a single
invocation, but for now I think this is a decent way to remediate the
risk of people globally installing multiple standard packages and 
invoking each from the user PATH.