### PR TITLE
Correct some inappropriate words

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="/docs/README-kokr.md">한국어 (Korean)</a> •
   <a href="/docs/README-ptbr.md">Português (Brasil)</a> •
   <a href="/docs/README-zhcn.md">简体中文 (Simplified Chinese)</a> •
-  <a href="/docs/README-zhtw.md">繁體中文 (Taiwanese Mandarin)</a>
+  <a href="/docs/README-zhtw.md">繁體中文 (Traditional Chinese)</a>
 </p>
 
 ## JavaScript style guide, linter, and formatter


### PR DESCRIPTION
繁體中文乃傳統中華文化所使用之中文書寫體系，上自商周，下迄 20 世紀一直是各地華人通用之中文書寫標準，目前仍廣泛用於台灣、香港、澳門等地，故不宜以 Taiwanese Mandarin 稱之。