### PR TITLE
Documentation: replaced depricated typescript eslint plugins with @typescript-eslint plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,18 +561,18 @@ be sure to install `babel-eslint` and `eslint-plugin-flowtype` globally as well,
 
 ### TypeScript
 
-To use TypeScript, you need to run `standard` with `typescript-eslint-parser` as the parser,
-`eslint-plugin-typescript` as a plugin, and tell standard to lint `*.ts` files (since it
+To use TypeScript, you need to run `standard` with `@typescript-eslint/parser` as the parser,
+`@typescript-eslint` as a plugin, and tell standard to lint `*.ts` files (since it
 doesn't by default).
 
 ```bash
-npm install typescript-eslint-parser eslint-plugin-typescript --save-dev
+npm install @typescript-eslint/parser @typescript-eslint/eslint-plugin --save-dev
 ```
 
 Then run:
 
 ```bash
-$ standard --parser typescript-eslint-parser --plugin typescript *.ts
+$ standard --parser @typescript-eslint/parser --plugin @typescript-eslint *.ts
 ```
 
 Or, add this to `package.json`:
@@ -580,8 +580,8 @@ Or, add this to `package.json`:
 ```json
 {
   "standard": {
-    "parser": "typescript-eslint-parser",
-    "plugins": [ "typescript" ]
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["@typescript-eslint"]
   }
 }
 ```
@@ -593,8 +593,8 @@ standard *.ts
 ```
 
 If `standard` is installed globally (i.e. `npm install standard --global`), then
-be sure to install `typescript-eslint-parser` and `eslint-plugin-typescript` globally as well,
-with `npm install typescript-eslint-parser eslint-plugin-typescript --global`.
+be sure to install `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` globally as well,
+with `npm install @typescript-eslint/parser @typescript-eslint/eslint-plugin --global`.
 
 ## What about Mocha, Jasmine, QUnit, etc?
 


### PR DESCRIPTION
Typescript plugins currently mentioned in readme file ("typescript-eslint-parser" and "eslint-plugin-typescript") are now [depricated](https://github.com/eslint/typescript-eslint-parser). This PR replaces those plugins with [new plugins](https://github.com/typescript-eslint/typescript-eslint), as recommended in old plugin repos.
I have tested new plugins with both the commands and in package.json file. They are working fine with standard.