### PR TITLE
fix(package): update eslint to version 5.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/standard/standard/issues"
   },
   "dependencies": {
-    "eslint": "~5.6.0",
+    "eslint": "~5.16.0",
     "eslint-config-standard": "12.0.0",
     "eslint-config-standard-jsx": "6.0.2",
     "eslint-plugin-import": "~2.14.0",


### PR DESCRIPTION
Closes #1251 

No repo should break