### PR TITLE
Release Proposal: 12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 12.1.0 - 2019-04-17
+
+- Bump `eslint` to 5.16.0
+- Fix `engines` property in `package.json`
+- Update `standard-engine` to the latest version
+- Lots of documentation updates
+
 ## 12.0.1 - 2018-08-29
 
 - Since ESLint 5 no longer supports Node 4, `standard` silently passes when run in Node 4, which matches the current behavior for Node 0.10, 0.12, and all other unsupported versions of Node.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "standard",
   "description": "JavaScript Standard Style",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "author": {
     "email": "feross@feross.org",
     "name": "Feross Aboukhadijeh",


### PR DESCRIPTION
I'm thinking we can release this on `2019-04-17` (next Wednesday) unless anyone has any objections ☺️ 

## 12.1.0 - 2019-04-17

- Bump `eslint` to 5.16.0
- Fix `engines` property in `package.json`
- Update `standard-engine` to the latest version
- Lots of documentation updates
