### PR TITLE
Align docs / Fix bad example

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ npm install @typescript-eslint/parser @typescript-eslint/eslint-plugin --save-de
 Then run:
 
 ```bash
-$ standard --parser @typescript-eslint/parser --plugin typescript *.ts
+$ standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin *.ts
 ```
 
 Or, add this to `package.json`:

--- a/docs/README-kokr.md
+++ b/docs/README-kokr.md
@@ -484,7 +484,7 @@ npm install @typescript-eslint/parser @typescript-eslint/eslint-plugin --save-de
 
 
 ```bash
-$ standard --parser @typescript-eslint/parser --plugin typescript *.ts
+$ standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin *.ts
 ```
 
 아니면, `package.json`에 아래 코드를 추가하세요.


### PR DESCRIPTION
Hi, 

The example for using this tool with typescript is partially wrong.

The example of running via the CLI with explicit args, is not aligned (and actually wrong)
with the example that includes args in the package.json.

The package.json example instructs to use @typescript-eslint/eslint-plugin as the plugin
while the former instructs using "typescript".

This PR addresses that.