### PR TITLE
added oxford comma for consistency with next line

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -183,7 +183,7 @@ your code.
   ```
 
 * **Declare browser globals** with a `/* global */` comment.<br>
-  Exceptions are: `window`, `document` and `navigator`.<br>
+  Exceptions are: `window`, `document`, and `navigator`.<br>
   Prevents accidental use of poorly-named browser globals like `open`, `length`,
   `event`, and `name`.
 


### PR DESCRIPTION
the first line of this rule description avoids the oxford comma, while the line below includes it.  

![standardjs](https://user-images.githubusercontent.com/38962121/61472663-ecfe1e00-a952-11e9-8142-e17cb532a9d7.png)

adding a comma on the first line after `document` would also serve to better differentiate inline code snippets from "normal text" font on the docs website, as they both have similar styles. 