### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-react": "~7.14.2",
     "eslint-plugin-standard": "~4.0.0",
-    "funding": "^1.0.0",
     "standard-engine": "^12.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove "funding" adware.

"funding" is a "paused" experiment and this commit removes it as a dependency from standard/standard, least ads come back in build logs unexpectedly.  By leaving this dependency in place it allows feross/funding to turn ads back on in standard/standard without any changes in standard/standard, this commit prevents that.