### PR TITLE
Don't run on Node.js versions less than 8.6.0

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
-if (process.version.match(/v(\d+)\./)[1] < 8) {
-  console.error('standard: Node 8 or greater is required. `standard` did not run.')
-} else {
+var match = process.version.match(/v(\d+)\.(\d+)/)
+var major = parseInt(match[1], 10)
+var minor = parseInt(match[2], 10)
+
+if (major >= 9 || (major === 8 && minor >= 6)) {
   require('standard-engine').cli(require('../options'))
+} else {
+  console.error('standard: Node 8 or greater is required. `standard` did not run.')
 }


### PR DESCRIPTION
ESLint uses the spread operator which isn't supported in Node.js versions earlier than 8.6.0.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Previously the cli would just check that the major version was 8 or above before continuing. This change now also looks at the minor version to ensure that the full version is v8.6.0 or above.
