### PR TITLE
Added package.json funding property

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
   "engines": {
     "node": ">=8"
   },
+  "funding": {
+    "type": "Tidelift",
+    "url": "https://tidelift.com/subscription/pkg/npm-standard"
+  },
   "homepage": "https://standardjs.com",
   "keywords": [
     "JavaScript Standard Style",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain:

### What changes did you make? (Give an overview)
**npm** just added a new [`npm fund` command](https://blog.npmjs.org/post/188841555980/updates-to-community-docs-more) in it's [v6.13.0](https://github.com/npm/cli/releases/tag/v6.13.0) release as part of the efforts to help out the OSS community.

This PR adds `funding` info to **standard** so that users depending on it can actually retrieve the funding url when they run `npm fund` in their projects.

Note: The funding information will only be available once a new version of the package is published to the npm registry.

### Which issue (if any) does this pull request address?
Funding

### Is there anything you'd like reviewers to focus on?
N/A