### PR TITLE
Add support for Node.js 8.3 - 8.6

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -4,8 +4,8 @@ var match = process.version.match(/v(\d+)\.(\d+)/)
 var major = parseInt(match[1], 10)
 var minor = parseInt(match[2], 10)
 
-if (major >= 9 || (major === 8 && minor >= 6)) {
+if (major >= 9 || (major === 8 && minor >= 3)) {
   require('standard-engine').cli(require('../options'))
 } else {
-  console.error('standard: Node 8 or greater is required. `standard` did not run.')
+  console.error('standard: Node 8.3 or greater is required. `standard` did not run.')
 }


### PR DESCRIPTION
The spread operator was actually introduced in Node.js 8.3. I think the typo comes from that node.green shows the latest version that has identical test results as earlier versions, and thus the column with green spread says "8.6.0", but hovering it shows it all the way down to "8.3.0".

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fixes a small error from #1418 