### PR TITLE
Don't run on Node.js versions less than 8.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 8.10.0
   - 8
   - 10
   - 12

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -4,8 +4,8 @@ var match = process.version.match(/v(\d+)\.(\d+)/)
 var major = parseInt(match[1], 10)
 var minor = parseInt(match[2], 10)
 
-if (major >= 9 || (major === 8 && minor >= 6)) {
+if (major >= 9 || (major === 8 && minor >= 10)) {
   require('standard-engine').cli(require('../options'))
 } else {
-  console.error('standard: Node 8 or greater is required. `standard` did not run.')
+  console.error('standard: Node 8.10.0 or greater is required. `standard` did not run.')
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tape": "^4.6.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.10.0"
   },
   "homepage": "https://standardjs.com",
   "keywords": [


### PR DESCRIPTION
ESLint uses the `s` (dotAll) flag for regular expressions which isn't supported in Node.js versions earlier than 8.10.0.

I made a similar PR for when the spread operator was introduced in Node.js v8.6.0: #1418

Once this lands, I'll rebase #1495 to make sure we test early Node.js versions in CI.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I changed the minimum Node.js version where `standard` will run to be 8.10.0 (was 8.6.0).

**Which issue (if any) does this pull request address?**

closes #1494
closes #1455

**Is there anything you'd like reviewers to focus on?**

Consider if this is actually a breaking change. If so we need to roll back the version of eslint instead of this. However, I think this be accepted so it's not breaking given the circumstances.