### PR TITLE
Support node 11

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -5,7 +5,7 @@ var match = process.version.match(/v(\d+)\.(\d+)/)
 var major = parseInt(match[1], 10)
 var minor = parseInt(match[2], 10)
 
-if (major >= 12 || (major === 10 && minor >= 12)) {
+if (major >= 11 || (major === 10 && minor >= 12)) {
   require('standard-engine').cli(require('../options'))
 } else {
   console.error('standard: Node 10.12.0 or greater is required. `standard` did not run.')


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**What changes did you make? (Give an overview)**

Currently, if you try to run standard using node v11, the executable outputs: `Node 10.12.0 or greater is required. standard did not run.`

Since v11 is greater than v10.12.0, this change makes the behaviour consistent with the messaging!
