### PR TITLE
Use hallmark to lint and fix markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -859,7 +859,7 @@ In `package.json`, use the "standard" property:
 
 ### Added
 
-- eslint-config-standard-react@1.2.0
+- `eslint-config-standard-react@1.2.0`
   - Disallow duplicate JSX properties
 
 ## [5.3.1] - 2015-09-18
@@ -868,7 +868,7 @@ In `package.json`, use the "standard" property:
 
 ### Changed
 
-- eslint-plugin-react@3.4.2
+- `eslint-plugin-react@3.4.2`
 
 ## [5.3.0] - 2015-09-16
 
@@ -876,13 +876,13 @@ In `package.json`, use the "standard" property:
 
 ### Changed
 
-- eslint-config-standard@4.4.0 ([history][eslint-config-standard])
+- `eslint-config-standard@4.4.0` ([history][eslint-config-standard])
   - **New rule:** must have space after semicolon in for-loop ([commit](https://github.com/standard/eslint-config-standard/commit/6e5025eef8900f686e19b4a31836743d98323119))
   - **New rule:** No default assignment with ternary operator ([commit](https://github.com/standard/eslint-config-standard/commit/0903c19ca6a8bc0c8625c41ca844ee69968bf948))
   - **New rule:** Require spaces before keywords ([commit](https://github.com/standard/eslint-config-standard/commit/656ba93cda9cd4ab38e032649aafb795993d5176))
-- eslint-config-standard-react@1.1.0 ([history][eslint-config-standard-react])
-- eslint-plugin-react@3.4.0 ([history][eslint-plugin-react])
-- eslint-plugin-standard@1.3.1 ([history][eslint-plugin-standard])
+- `eslint-config-standard-react@1.1.0` ([history][eslint-config-standard-react])
+- `eslint-plugin-react@3.4.0` ([history][eslint-plugin-react])
+- `eslint-plugin-standard@1.3.1` ([history][eslint-plugin-standard])
 
 ## [5.2.2] - 2015-09-08
 
@@ -900,12 +900,12 @@ In `package.json`, use the "standard" property:
 
 ### Changed
 
-- eslint-config-standard@4.3.1 ([history][eslint-config-standard])
+- `eslint-config-standard@4.3.1` ([history][eslint-config-standard])
   - **Revert rule**: Disallow unncessary concatenation of strings
 
 ### Fixed
 
-- eslint-config-standard@4.3.1 ([history][eslint-config-standard])
+- `eslint-config-standard@4.3.1` ([history][eslint-config-standard])
   - fix regression with ternary operator handling
 
 ## [5.2.0] - 2015-09-03
@@ -914,7 +914,7 @@ In `package.json`, use the "standard" property:
 
 ### Added
 
-- eslint-config-standard@4.3.0 ([history][eslint-config-standard])
+- `eslint-config-standard@4.3.0` ([history][eslint-config-standard])
   - **New rule:** Disallow unncessary concatenation of strings
   - **New rule:** Disallow duplicate name in class members
   - **New rule:** enforce spaces inside of single line blocks
@@ -923,12 +923,12 @@ In `package.json`, use the "standard" property:
 ### Changed
 
 - Bump `eslint` from 1.1.0 to 1.3.1 ([CHANGELOG][eslint])
-- eslint-plugin-standard@1.3.0 ([history][eslint-plugin-standard])
+- `eslint-plugin-standard@1.3.0` ([history][eslint-plugin-standard])
   - A small change to make the plugin compatible with browserify which does not affect behavior.
 
 ### Fixed
 
-- eslint-plugin-react@3.3.1 ([CHANGELOG][eslint-plugin-react])
+- `eslint-plugin-react@3.3.1` ([CHANGELOG][eslint-plugin-react])
   - Fix object rest/spread handling.
 - Added white background to badge.svg to make it work with dark backgrounds ([Closes #234](https://github.com/standard/standard/issues/234))
 - Minor updates to README.md
@@ -950,9 +950,9 @@ In `package.json`, use the "standard" property:
 
 ### Fixed
 
-- eslint-config-standard@4.1.0 ([history][eslint-config-standard])
+- `eslint-config-standard@4.1.0` ([history][eslint-config-standard])
   - Added rest/spread feature to `eslintrc.json` to fix [#226](https://github.com/standard/standard/issues/226) and [eslint-plugin-standard#3](https://github.com/xjamundx/eslint-plugin-standard/issues/3)
-- eslint-plugin-react@3.2.2 ([CHANGELOG][eslint-plugin-react])
+- `eslint-plugin-react@3.2.2` ([CHANGELOG][eslint-plugin-react])
   - Fix crash when propTypes don't have any parent
   - Fix jsx-no-literals reporting errors outside JSX
 
@@ -968,7 +968,7 @@ In `package.json`, use the "standard" property:
 
 ### Changed
 
-- eslint-config-standard-react@1.0.4 ([history][eslint-config-standard-react])
+- `eslint-config-standard-react@1.0.4` ([history][eslint-config-standard-react])
   - **Disable Rule:** react/wrap-multilines
 - Minor README updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1048,8 +1048,6 @@ In `package.json`, use the "standard" property:
 
 [view diff](https://github.com/standard/standard/compare/v3.9.0...v4.0.0)
 
-[unreleased]: https://github.com/standard/standard/compare/v16.0.3...HEAD
-
 [16.0.3]: https://github.com/standard/standard/compare/v16.0.2...v16.0.3
 
 [16.0.2]: https://github.com/standard/standard/compare/v16.0.1...v16.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ code to match the newly added rules.
 ❤️ If you enjoy StandardJS and want to support future releases, please
 [support Feross](https://github.com/users/feross/sponsorship)!
 
-### New features
+### Added
 
 - 🏎 Better performance: the filesystem doesn't need to be traversed multiple times! [#1023](https://github.com/standard/standard/issues/1023)
   - Massive improvements (on the order of minutes!) for projects with huge folders which are are ignored with `.gitignore`
@@ -67,6 +67,7 @@ code to match the newly added rules.
 - 🌟 Support relative paths from the command line in more situations (e.g. `standard ../src/*.js`) [#1384](https://github.com/standard/standard/issues/1384)
 
 - 🌟 New `extensions` option for linting additional extensions besides `.js`, `.jsx`, `.mjs`, and `.cjs`
+
   - Can be configured with the `--ext` command line flag or in `package.json`:
   - Example:
 
@@ -84,24 +85,7 @@ code to match the newly added rules.
 
 - 🌟 New cache directory location, respecting `XDG_CACHE_HOME` preference, with fallback to `~/.cache/standard` [standard-engine/#214](https://github.com/standard/standard-engine/pull/214)
 
-### Changed features
-
-- Update `eslint` from `~7.11.0` to `~7.12.1`
-
-- Update `standard-engine` from `^12` to `^14`
-  - Fix inaccurate `--help` command which indicates that `bundle.js` is automatically ignored when it is not anymore [standard-engine/#224](https://github.com/standard/standard-engine/pull/224)
-  - Remove `deglob` package and use built-in ESLint folder-traversal support
-
-- Paths with square brackets (e.g. `[` and `]`) are no longer skipped [#1333](https://github.com/standard/standard/issues/1333)
-  - This pattern is particularly common in Next.js apps, e.g. `blog/[slug].js`
-  - You may notice new errors in these files since they were not being linted before
-
-- Better mono-repo support: Nested `node_modules/` folders are ignored by default [#1182](https://github.com/standard/standard/issues/1182)
-
-- Remove `eslint-plugin-standard` [#1316](https://github.com/standard/standard/issues/1316)
-  - We migrated the remaining `no-callback-literal` rule into `eslint-plugin-node`
-
-### New rules
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -129,7 +113,24 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 - JSX: Enforce JSX value is returned in component render function ([react/require-render-return](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md)) [#1565](https://github.com/standard/standard/issues/1565) (0%)
 - JSX: Prevent usage of unsafe `target='_blank'` on any component named `Link` ([react/jsx-no-target-blank](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)) [#1576](https://github.com/standard/standard/issues/1576) (0%)
 
-### Changed rules
+### Changed
+
+- Update `eslint` from `~7.11.0` to `~7.12.1`
+
+- Update `standard-engine` from `^12` to `^14`
+  - Fix inaccurate `--help` command which indicates that `bundle.js` is automatically ignored when it is not anymore [standard-engine/#224](https://github.com/standard/standard-engine/pull/224)
+  - Remove `deglob` package and use built-in ESLint folder-traversal support
+
+- Paths with square brackets (e.g. `[` and `]`) are no longer skipped [#1333](https://github.com/standard/standard/issues/1333)
+  - This pattern is particularly common in Next.js apps, e.g. `blog/[slug].js`
+  - You may notice new errors in these files since they were not being linted before
+
+- Better mono-repo support: Nested `node_modules/` folders are ignored by default [#1182](https://github.com/standard/standard/issues/1182)
+
+- Remove `eslint-plugin-standard` [#1316](https://github.com/standard/standard/issues/1316)
+  - We migrated the remaining `no-callback-literal` rule into `eslint-plugin-node`
+
+#### Changed rules
 
 - Relax rule: JSX: Consider the global scope when checking for defined Components [#1115](https://github.com/standard/standard/issues/1115)
 - Relax rule: JSX: Remove conflicting indentation rule in `indent` [#1499](https://github.com/standard/standard/issues/1499)
@@ -153,7 +154,19 @@ code to match the newly added rules.
 ❤️ If you enjoy StandardJS and want to support future releases, check out
 Feross's [GitHub Sponsors page](https://github.com/users/feross/sponsorship).
 
-### New features
+### Changed
+
+- BREAKING: Node.js 8 is no longer supported
+  - Node.js 8 is EOL and will no longer be receiving security updates.
+  - To prevent breaking CI for projects which still support Node 8, `standard` silently passes when run by an unsupported version of Node
+- Update `eslint` from `~6.8.0` to `~7.11.0`
+
+#### Changed rules
+
+- Relax rule: Allow function declarations in nested blocks [#1406](https://github.com/standard/standard/issues/1406)
+- Relax rule: Removed redundant `no-negated-in-lhs` rule, already enforced by `no-unsafe-negation` [eslint-config-standard/#160](https://github.com/standard/eslint-config-standard/pull/160)
+
+### Added
 
 - Support ES 2021, the latest version of the ECMAScript specification, which includes support for [logical assignment operators](https://github.com/tc39/proposal-logical-assignment) and [numeric separators](https://github.com/tc39/proposal-numeric-separator) [#1551](https://github.com/standard/standard/issues/1551)
 - Support ES 2020 features such as [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator), `export * as ns from 'source'`, and [`import.meta`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta).
@@ -163,14 +176,7 @@ Feross's [GitHub Sponsors page](https://github.com/users/feross/sponsorship).
   - Other community contributed translations exist in Spanish, French, Italian, Japanese, Korean, Portuguese, Simplified Chinese, and Taiwanese Mandarin.
   - More translations are always welcome!
 
-### Changed features
-
-- BREAKING: Node.js 8 is no longer supported
-  - Node.js 8 is EOL and will no longer be receiving security updates.
-  - To prevent breaking CI for projects which still support Node 8, `standard` silently passes when run by an unsupported version of Node
-- Update `eslint` from `~6.8.0` to `~7.11.0`
-
-### New rules
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -180,11 +186,6 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 - Disallow useless backreferences in regular expressions ([no-useless-backreference](https://eslint.org/docs/rules/no-useless-backreference)) [#1554](https://github.com/standard/standard/issues/1554) (0%)
 - Enforce default clauses in switch statements to be last ([default-case-last](https://eslint.org/docs/rules/default-case-last)) [#1553](https://github.com/standard/standard/issues/1553) (0%)
 - Disallow Number Literals That Lose Precision ([no-loss-of-precision](https://eslint.org/docs/rules/no-loss-of-precision)) [#1552](https://github.com/standard/standard/issues/1552) (0%)
-
-### Changed rules
-
-- Relax rule: Allow function declarations in nested blocks [#1406](https://github.com/standard/standard/issues/1406)
-- Relax rule: Removed redundant `no-negated-in-lhs` rule, already enforced by `no-unsafe-negation` [eslint-config-standard/#160](https://github.com/standard/eslint-config-standard/pull/160)
 
 ## [14.3.4] - 2020-05-11
 
@@ -252,18 +253,14 @@ maintainers, ask questions, and get help from the community!
 Feross's [GitHub Sponsors page](https://github.com/users/feross/sponsorship).
 GitHub is matching donations, so your dollars go twice as far! 🚀
 
-### New features
+### Added
 
 - Support ES 2019, the latest version of the ECMAScript specification. [eslint-config-standard/e04e06](https://github.com/standard/eslint-config-standard/commit/e04e0615fdea44567bfb2fd1f868e3ab6751bda3)
 - Lint `*.mjs` and `*.cjs` files automatically by default [#1009](https://github.com/standard/standard/issues/1009)
 - Ignore patterns from `.git/info/exclude` in addition to `.gitignore`. [#1277](https://github.com/standard/standard/issues/1277)
 - Added [`funding`](https://github.com/feross/funding), an open source funding experiment.
 
-### Changed features
-
-- Remove `bundle.js` from the default list of ignored files [#743](https://github.com/standard/standard/issues/743)
-
-### New rules
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -291,7 +288,11 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 - Require pipeline operators to appear at the start of a line ([operator-linebreak](https://eslint.org/docs/rules/operator-linebreak)) [eslint-config-standard/#121](https://github.com/standard/eslint-config-standard/pull/121) (0%)
 - Disallow use of the void operator ([no-void](https://eslint.org/docs/rules/no-void)) [eslint-config-standard/#135](https://github.com/standard/eslint-config-standard/pull/135) (0%)
 
-### Changed rules
+### Changed
+
+- Remove `bundle.js` from the default list of ignored files [#743](https://github.com/standard/standard/issues/743)
+
+#### Changed rules
 
 - Relax rule: Don't require newlines between _single-line_ member functions or class field declarations ([lines-between-class-members](https://eslint.org/docs/rules/lines-between-class-members)) [#1347](https://github.com/standard/standard/issues/1347)
 - Relax rule: Don't check indentation on template literal children (work around for ESLint bug) ([indent](https://eslint.org/docs/rules/indent)) [#1176](https://github.com/standard/standard/issues/1176)
@@ -307,7 +308,7 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 
 ## [13.0.1] - 2019-07-11
 
-### Changed rules
+### Changed
 
 - Relax rule: Only enforce `const` in destructuring when all variables are constant [#1325](https://github.com/standard/standard/issues/1325)
 
@@ -327,7 +328,7 @@ When you upgrade, consider running `standard --fix` to automatically format your
 
 ❤️ If you enjoy StandardJS and want to support future releases, check out Feross's [GitHub Sponsors page](https://github.com/users/feross/sponsorship). GitHub is matching donations, so your dollars go twice as far! 🚀
 
-### New features
+### Changed
 
 - Update `eslint` from `~5.16.0` to `~6.0.1`
   - BREAKING: Node.js 6 is no longer supported
@@ -344,7 +345,9 @@ When you upgrade, consider running `standard --fix` to automatically format your
 - Update `eslint-plugin-promise` from `~4.0.0` to `~4.2.1`
 - Update `eslint-plugin-node` from `~7.0.1` to `~9.1.0`
 
-### New rules
+### Added
+
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -368,7 +371,7 @@ New version of ESLint, new version of Standard!
 
 When you upgrade, consider running `standard --fix` to automatically format your code to match the newly added rules.
 
-### New features
+### Added
 
 - Update `eslint` from `~4.19.0` to `~5.4.0`.
   - Support JSXFragment nodes (e.g. `<></>`)
@@ -377,7 +380,7 @@ When you upgrade, consider running `standard --fix` to automatically format your
   - Other community contributed translations exist in Spanish, Italian, Korean, Portuguese, Simplified Chinese, and Taiwanese Mandarin.
   - More translations are welcome!
 
-### New rules
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -386,10 +389,6 @@ _(Estimated % of affected standard users, based on test suite in parens)_
   - e.g. `assert.equal()`, `assert.deepEqual()` and `assert.notEqual()` were deprecated in Node 10.
 - Disallow self assignment of properties ([no-self-assign](https://eslint.org/docs/rules/no-self-assign)) [#1186](https://github.com/standard/standard/issues/1186) (0%)
 - Disallow use of an exported name as the locally imported name of a default export ([import/no-named-as-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md)) [eslint-config-standard/#98](https://github.com/standard/eslint-config-standard/pull/98)
-
-### Changed rules
-
-None.
 
 ## [11.0.0] - 2018-02-18
 
@@ -400,7 +399,7 @@ the indentation rules more strict.
 Thankfully, most users will just need to run `standard --fix` to update code to be
 compliant.
 
-### New features
+### Changed
 
 - Update `eslint` from ~3.19.0 to ~4.18.0.
   - The `indent` rule is more strict.
@@ -421,7 +420,7 @@ compliant.
   - The `no-deprecated-api` rule is updated with Node.js 8 support and improved
     Node 6 support.
 
-- Upodate `eslint-plugin-promise` from `~3.5.0` to `~3.6.0`.
+- Update `eslint-plugin-promise` from `~3.5.0` to `~3.6.0`.
 
 - Update `eslint-plugin-react` from `~6.10.0` to `~7.6.1`
   - Fix `jsx-indent` crash
@@ -431,7 +430,7 @@ compliant.
   - Fix `jsx-curly-spacing` schema incompatibility with ESLint 4.2.0.
   - Fix alignment bug in `jsx-indent`.
 
-### Changed rules
+#### Changed rules
 
 - Relax rule: Don't mark Rails Asset Pipeline comments (comments that start with `//=`)
   as errors. ([spaced-comment](https://eslint.org/docs/rules/spaced-comment)) [#918](https://github.com/standard/standard/issues/918)
@@ -445,7 +444,7 @@ release!
 
 ## [10.0.2] - 2017-04-14
 
-### Changed rules
+### Changed
 
 - Relax rule: Disallow import of modules using absolute paths ([import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)) [#861](https://github.com/standard/standard/issues/861)
   - This rule was responsible for up to 25% of the running time of `standard`, so we are disabling it until its performance improves.
@@ -489,12 +488,11 @@ React, JSX, and Flow.
 When you upgrade, consider running `standard --fix` to automatically fix some of
 the issues caught by this new version.
 
-### New features
+### Added
 
-- Update ESLint from 3.15.x to 3.19.x.
 - Node.js API: Add `standard.lintTextSync` method
 
-### New rules
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -513,7 +511,11 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 - Disallow Webpack loader syntax in imports ([import/no-webpack-loader-syntax](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)) [#806](https://github.com/standard/standard/issues/806) (0%)
 - Disallow comparing against -0 ([no-compare-neg-zero](https://eslint.org/docs/rules/no-compare-neg-zero)) [#812](https://github.com/standard/standard/issues/812) (0%)
 
-### Changed rules
+### Changed
+
+- Update ESLint from 3.15.x to 3.19.x.
+
+#### Changed rules
 
 - Relax rule: allow using `...rest` to omit properties from an object ([no-unused-vars](https://eslint.org/docs/rules/no-unused-vars)) [#800](https://github.com/standard/standard/issues/800)
   - This is a common and useful pattern in React/JSX apps!
@@ -526,13 +528,13 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 
 ## [9.0.2] - 2017-03-17
 
-### Changed rules
+### Changed
 
 - Relax rule: Allow tagged template string expressions ([no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions)) [#822](https://github.com/standard/standard/issues/822)
 
 ## [9.0.1] - 2017-03-07
 
-### Changed rules
+### Changed
 
 - Relax rule: Allow mixing basic operators without parens ([no-mixed-operators](https://eslint.org/docs/rules/no-mixed-operators)) [#816](https://github.com/standard/standard/issues/816)
   - Specifically, these operators: `+`, `-`, `*`, `/`, `%`, and `**`
@@ -556,12 +558,12 @@ errors caught by the new rules in this version.
 _Note: If you use the Chai test framework, you will need to make some changes to
 your tests to improve their robustness. [Read about the changes you need to make](https://github.com/standard/standard/issues/690#issuecomment-278533482)._
 
-### New features
+### Added
 
 - Update ESLint from 3.10.x to 3.15.x
 - 3 additional rules are now fixable with `standard --fix`
 
-### New rules
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -579,7 +581,9 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 - Disallow padding within switch statements and classes ([padded-blocks](https://eslint.org/docs/rules/padded-blocks)) [#610](https://github.com/standard/standard/issues/610) (0%)
 - Enforce that Symbols are passed a description ([symbol-description](https://eslint.org/docs/rules/symbol-description)) [#630](https://github.com/standard/standard/issues/630) (0%)
 
-### Changed rules
+### Changed
+
+#### Changed rules
 
 - Relax rule: allow TypeScript Triple-Slash Directives ([spaced-comment](https://eslint.org/docs/rules/spaced-comment)) [#660](https://github.com/standard/standard/issues/660)
 - Relax rule: allow Flow Comments ([spaced-comment](https://eslint.org/docs/rules/spaced-comment)) [#661](https://github.com/standard/standard/issues/661)
@@ -658,14 +662,14 @@ All bug fixes and enhancements will land in `standard` v8.x.
 
 Full changelog below. Cheers!
 
-### New features
+### Added
 
 - Upgrade to ESLint v3 (<https://eslint.org/docs/user-guide/migrating-to-3.0.0>) [#565](https://github.com/standard/standard/pull/565)
   - **BREAKING:** Drop support for node &lt; 4 (this was a decision made by the ESLint team)
 - Expose ESLint's `--fix` command line flag [#540](https://github.com/standard/standard/issues/540) [standard-engine/#107](https://github.com/Flet/standard-engine/issues/107)
   - Lightweight, no additional dependencies, fixes dozens of rules automatically
 
-### New rules
+#### New rules
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
@@ -680,7 +684,9 @@ _(Estimated % of affected standard users, based on test suite in parens)_
 - Disallow template literal placeholder syntax in regular strings ([no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)) [#594](https://github.com/standard/standard/issues/594) (0%)
 - Disallow tabs in file ([no-tabs](https://eslint.org/docs/rules/no-tabs)) [#593](https://github.com/standard/standard/issues/593) (0%)
 
-### Changed rules
+### Changed
+
+#### Changed rules
 
 - Relax rule: Allow template literal strings (backtick strings) to avoid escaping [#421](https://github.com/standard/standard/issues/421)
 - Relax rule: Do not enforce spacing around \* in generator functions ([#564 (comment)](https://github.com/standard/standard/issues/564#issuecomment-234699126))
@@ -709,12 +715,14 @@ export * from 'bar'
 
 ## [7.0.0] - 2016-05-02
 
-### Changes
+### Changed
 
 - Upgrade eslint to version ~2.9.0
 - Remove "rules" configuration option [#367](https://github.com/standard/standard/issues/367) from `package.json` (Reasoning is [here](https://github.com/standard/standard/issues/399#issuecomment-180961891))
 
-### New rules
+### Added
+
+#### New rules
 
 _Estimated % of affected standard users, based on test suite_
 
@@ -727,7 +735,9 @@ _Estimated % of affected standard users, based on test suite_
 - Disallow unnecessary computed property keys on objects ([no-useless-computed-key](https://eslint.org/docs/rules/no-useless-computed-key)) (0%)
 - Validate spacing before closing bracket in JSX ([react/jsx-space-before-closing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md)) (0%)
 
-### Removed rules
+### Removed
+
+#### Removed rules
 
 - Require parens in arrow function arguments ([arrow-parens](https://eslint.org/docs/rules/arrow-parens))
 
@@ -769,20 +779,28 @@ _Estimated % of affected standard users, based on test suite_
 
 The goal of this release is to make `standard` faster to install, and simpler to use.
 
-### Remove `standard-format` ([#340](https://github.com/standard/standard/issues/340)) ([#397](https://github.com/standard/standard/issues/397))
+### Removed
 
-- Eliminates 250 packages, and cuts install time in half!
-- For npm 2, install time goes from 20 secs —> 10 secs.
-- For npm 3, install time goes from 24 secs —> 12 secs.
-- To continue using `standard-format`, just install it separately: `npm install -g standard-format`
+- Remove `standard-format` ([#340](https://github.com/standard/standard/issues/340)) ([#397](https://github.com/standard/standard/issues/397))
 
-### React-specific linting rules are removed ([#351](https://github.com/standard/standard/issues/351)) ([#367](https://github.com/standard/standard/issues/367)) ([eslint-config-standard-react/#13](https://github.com/standard/eslint-config-standard-react/pull/13))
+  - Eliminates 250 packages, and cuts install time in half!
+  - For npm 2, install time goes from 20 secs —> 10 secs.
+  - For npm 3, install time goes from 24 secs —> 12 secs.
+  - To continue using `standard-format`, just install it separately: `npm install -g standard-format`
 
-- JSX is still supported, and it continues to be checked for style.
-- There were only a few React-specific rules, but they made it extremely difficult for users of alternatives like `virtual-dom` or `deku`, and unecessarily tied `standard` to a single library.
-- JSX rules come from `eslint-config-standard-jsx`. The `eslint-config-standard-react` dependency was removed.
+- Remove React-specific linting rules ([#351](https://github.com/standard/standard/issues/351)) ([#367](https://github.com/standard/standard/issues/367)) ([eslint-config-standard-react/#13](https://github.com/standard/eslint-config-standard-react/pull/13))
 
-### New Rules
+  - JSX is still supported, and it continues to be checked for style.
+  - There were only a few React-specific rules, but they made it extremely difficult for users of alternatives like `virtual-dom` or `deku`, and unecessarily tied `standard` to a single library.
+  - JSX rules come from `eslint-config-standard-jsx`. The `eslint-config-standard-react` dependency was removed.
+
+#### Removed rules
+
+- `parseInt()` radix rule because ES5 fixes this issue ([#384](https://github.com/standard/standard/issues/384)) ([radix](https://eslint.org/docs/2.0.0/rules/radix.html)) (0%)
+
+### Added
+
+#### New Rules
 
 _The percentage (%) of users that rule changes will effect, based on real-world testing of the top ~400 npm packages is denoted in brackets._
 
@@ -800,11 +818,9 @@ _The percentage (%) of users that rule changes will effect, based on real-world 
 - Disallow Symbol Constructor ([no-new-symbol](https://eslint.org/docs/2.0.0/rules/no-new-symbol)) (0%)
 - Disallow Self Assignment ([no-self-assign](https://eslint.org/docs/2.0.0/rules/no-self-assign)) (0%)
 
-### Removed Rules
+### Changed
 
-- `parseInt()` radix rule because ES5 fixes this issue ([#384](https://github.com/standard/standard/issues/384)) ([radix](https://eslint.org/docs/2.0.0/rules/radix.html)) (0%)
-
-### Expose eslint configuration via command line options and `package.json`
+#### Expose eslint configuration via command line options and `package.json`
 
 For power users, it might be easier to use one of these new hooks instead of forking
 `standard`, though that's still encouraged, too!
@@ -825,25 +841,25 @@ In `package.json`, use the "standard" property:
 }
 ```
 
-### Upgrade to ESLint v2
+#### Upgrade to ESLint v2
 
 - There may be slight behavior changes to existing rules. When possible, we've noted these in the "New Rules" and "Removed Rules" section.
 
-### Improve test suite
+#### Improve test suite
 
 - Rule changes can be tested against every package on npm. For sanity, this is limited to packages with at least 4 dependents. Around 400 packages.
 
-### Known Issues
+#### Known Issues
 
 - Using prerelease eslint version (2.0.0-rc.0). There may be breaking changes before the stable release.
 - `no-return-assign` behavior changed with arrow functions ([eslint/eslint#5150](https://github.com/eslint/eslint/issues/5150))
 
-### Relevant diffs
+#### Relevant diffs
 
-- standard ([v5.4.1...v6.0.0](https://github.com/standard/standard/compare/v5.4.1...v6.0.0))
-- eslint-config-standard ([v4.4.0...v5.0.0](https://github.com/standard/eslint-config-standard/compare/v4.4.0...v5.0.0))
-- eslint-config-standard-jsx ([v1.0.0](https://github.com/standard/eslint-config-standard-jsx/commit/47d5e248e2e078eb87619493999e3e74d4b7e70e))
-- standard-engine ([v2.2.4...v3.2.1](https://github.com/Flet/standard-engine/compare/v2.2.4...v3.2.1))
+- `standard` ([v5.4.1...v6.0.0](https://github.com/standard/standard/compare/v5.4.1...v6.0.0))
+- `eslint-config-standard` ([v4.4.0...v5.0.0](https://github.com/standard/eslint-config-standard/compare/v4.4.0...v5.0.0))
+- `eslint-config-standard-jsx` ([v1.0.0](https://github.com/standard/eslint-config-standard-jsx/commit/47d5e248e2e078eb87619493999e3e74d4b7e70e))
+- `standard-engine` ([v2.2.4...v3.2.1](https://github.com/Flet/standard-engine/compare/v2.2.4...v3.2.1))
 
 ## [5.4.1] - 2015-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,29 +105,29 @@ code to match the newly added rules.
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Require let or const instead of var ([no-var](https://eslint.org/docs/rules/no-var)) [#633](https://github.com/standard/standard/issues/633) [75%] [automatic fixing reduces to 11%]
-- Enforce return statements in `Array` method callbacks ([array-callback-return](https://eslint.org/docs/rules/array-callback-return)) [#859](https://github.com/standard/standard/issues/859) [7%]
-- Disallow empty block statements ([no-empty](https://eslint.org/docs/rules/no-empty)) [#796](https://github.com/standard/standard/issues/796) [2%]
-- Enforce default parameters to be last ([default-param-last](https://eslint.org/docs/rules/default-param-last)) [#1414](https://github.com/standard/standard/issues/1414) [1%]
-- Disallow use of the `RegExp` constructor in favor of regular expression literals ([prefer-regex-literals](https://eslint.org/docs/rules/prefer-regex-literals)) [#1413](https://github.com/standard/standard/issues/1413) [1%]
-- Disallow spaces inside of computed keys of class methods, getters and setters ([computed-property-spacing](https://eslint.org/docs/rules/computed-property-spacing)) [#1416](https://github.com/standard/standard/issues/1416) [0%]
-- Disallow `case NaN`, `switch(NaN)`, `indexOf(NaN)`, and `lastIndexOf(NaN)` ([use-isnan](https://eslint.org/docs/rules/use-isnan)) [#1429](https://github.com/standard/standard/issues/1429) [0%]
-- Disallow assigning to imported bindings ([no-import-assign](https://eslint.org/docs/rules/no-import-assign)) [#1412](https://github.com/standard/standard/issues/1412) [0%]
-- Enforce getter/setter pairs in classes ([accessor-pairs](https://eslint.org/docs/rules/accessor-pairs)) [#1415](https://github.com/standard/standard/issues/1415) [0%]
-- Node: Disallow assignment to `exports` ([node/no-exports-assign](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-exports-assign.md)) [#1400](https://github.com/standard/standard/issues/1400) [0%]
-- React: Prevent usage of the return value of `ReactDOM.render` ([react/no-render-return-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md)) [#1568](https://github.com/standard/standard/issues/1568) [1%]
-- React: Prevent usage of deprecated methods ([react/no-deprecated](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md)) [#1572](https://github.com/standard/standard/issues/1572) [1%]
-- React: Prevent direct mutation of `this.state` ([react/no-direct-mutation-state](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md)) [#1571](https://github.com/standard/standard/issues/1571) [0%]
-- React: Prevent usage of `findDOMNode` ([react/no-find-dom-node](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md)) [#1570](https://github.com/standard/standard/issues/1570) [0%]
-- React: Prevent usage of `isMounted` ([react/no-is-mounted](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md)) [#1569](https://github.com/standard/standard/issues/1569) [0%]
-- React: Prevent using string refs ([react/no-string-refs](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md)) [#1567](https://github.com/standard/standard/issues/1567) [0%]
+- Require let or const instead of var ([no-var](https://eslint.org/docs/rules/no-var)) [#633](https://github.com/standard/standard/issues/633) (75%) (automatic fixing reduces to 11%)
+- Enforce return statements in `Array` method callbacks ([array-callback-return](https://eslint.org/docs/rules/array-callback-return)) [#859](https://github.com/standard/standard/issues/859) (7%)
+- Disallow empty block statements ([no-empty](https://eslint.org/docs/rules/no-empty)) [#796](https://github.com/standard/standard/issues/796) (2%)
+- Enforce default parameters to be last ([default-param-last](https://eslint.org/docs/rules/default-param-last)) [#1414](https://github.com/standard/standard/issues/1414) (1%)
+- Disallow use of the `RegExp` constructor in favor of regular expression literals ([prefer-regex-literals](https://eslint.org/docs/rules/prefer-regex-literals)) [#1413](https://github.com/standard/standard/issues/1413) (1%)
+- Disallow spaces inside of computed keys of class methods, getters and setters ([computed-property-spacing](https://eslint.org/docs/rules/computed-property-spacing)) [#1416](https://github.com/standard/standard/issues/1416) (0%)
+- Disallow `case NaN`, `switch(NaN)`, `indexOf(NaN)`, and `lastIndexOf(NaN)` ([use-isnan](https://eslint.org/docs/rules/use-isnan)) [#1429](https://github.com/standard/standard/issues/1429) (0%)
+- Disallow assigning to imported bindings ([no-import-assign](https://eslint.org/docs/rules/no-import-assign)) [#1412](https://github.com/standard/standard/issues/1412) (0%)
+- Enforce getter/setter pairs in classes ([accessor-pairs](https://eslint.org/docs/rules/accessor-pairs)) [#1415](https://github.com/standard/standard/issues/1415) (0%)
+- Node: Disallow assignment to `exports` ([node/no-exports-assign](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-exports-assign.md)) [#1400](https://github.com/standard/standard/issues/1400) (0%)
+- React: Prevent usage of the return value of `ReactDOM.render` ([react/no-render-return-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md)) [#1568](https://github.com/standard/standard/issues/1568) (1%)
+- React: Prevent usage of deprecated methods ([react/no-deprecated](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md)) [#1572](https://github.com/standard/standard/issues/1572) (1%)
+- React: Prevent direct mutation of `this.state` ([react/no-direct-mutation-state](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md)) [#1571](https://github.com/standard/standard/issues/1571) (0%)
+- React: Prevent usage of `findDOMNode` ([react/no-find-dom-node](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md)) [#1570](https://github.com/standard/standard/issues/1570) (0%)
+- React: Prevent usage of `isMounted` ([react/no-is-mounted](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md)) [#1569](https://github.com/standard/standard/issues/1569) (0%)
+- React: Prevent using string refs ([react/no-string-refs](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md)) [#1567](https://github.com/standard/standard/issues/1567) (0%)
 - JSX: Prevent missing parentheses around multiline JSX ([react/jsx-wrap-multilines](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)) [#710](https://github.com/standard/standard/issues/710) [#1382](https://github.com/standard/standard/issues/1382) (0%)
-- JSX: Check if shorthand fragment syntax requires a key prop ([react/jsx-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)) [#1575](https://github.com/standard/standard/issues/1575) [0%]
-- JSX: Prevent passing of children as props ([react/no-children-prop](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md)) [#1574](https://github.com/standard/standard/issues/1574) [0%]
-- JSX: Prevent using children and dangerouslySetInnerHTML as props at the same time ([react/no-danger-with-children](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md)) [#1573](https://github.com/standard/standard/issues/1573) [0%]
-- JSX: Prevent invalid characters from appearing in markup ([react/no-unescaped-entities](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md)) [#1566](https://github.com/standard/standard/issues/1566) [0%]
-- JSX: Enforce JSX value is returned in component render function ([react/require-render-return](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md)) [#1565](https://github.com/standard/standard/issues/1565) [0%]
-- JSX: Prevent usage of unsafe `target='_blank'` on any component named `Link` ([react/jsx-no-target-blank](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)) [#1576](https://github.com/standard/standard/issues/1576) [0%]
+- JSX: Check if shorthand fragment syntax requires a key prop ([react/jsx-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)) [#1575](https://github.com/standard/standard/issues/1575) (0%)
+- JSX: Prevent passing of children as props ([react/no-children-prop](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md)) [#1574](https://github.com/standard/standard/issues/1574) (0%)
+- JSX: Prevent using children and dangerouslySetInnerHTML as props at the same time ([react/no-danger-with-children](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md)) [#1573](https://github.com/standard/standard/issues/1573) (0%)
+- JSX: Prevent invalid characters from appearing in markup ([react/no-unescaped-entities](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md)) [#1566](https://github.com/standard/standard/issues/1566) (0%)
+- JSX: Enforce JSX value is returned in component render function ([react/require-render-return](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md)) [#1565](https://github.com/standard/standard/issues/1565) (0%)
+- JSX: Prevent usage of unsafe `target='_blank'` on any component named `Link` ([react/jsx-no-target-blank](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)) [#1576](https://github.com/standard/standard/issues/1576) (0%)
 
 ### Changed rules
 
@@ -174,12 +174,12 @@ Feross's [GitHub Sponsors page](https://github.com/users/feross/sponsorship).
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Require indentation for values of ternary expressions ([indent](https://eslint.org/docs/rules/indent)) [#927](https://github.com/standard/standard/issues/927) [4%]
-- Enforce newlines between operands of ternary expressions if the expression spans multiple lines ([multiline-ternary](https://eslint.org/docs/rules/multiline-ternary)) [#1558](https://github.com/standard/standard/issues/1558) [3%]
-- Disallow loops with a body that allows only one iteration ([no-unreachable-loop](https://eslint.org/docs/rules/no-unreachable-loop)) [#1556](https://github.com/standard/standard/issues/1556) [0%]
-- Disallow useless backreferences in regular expressions ([no-useless-backreference](https://eslint.org/docs/rules/no-useless-backreference)) [#1554](https://github.com/standard/standard/issues/1554) [0%]
-- Enforce default clauses in switch statements to be last ([default-case-last](https://eslint.org/docs/rules/default-case-last)) [#1553](https://github.com/standard/standard/issues/1553) [0%]
-- Disallow Number Literals That Lose Precision ([no-loss-of-precision](https://eslint.org/docs/rules/no-loss-of-precision)) [#1552](https://github.com/standard/standard/issues/1552) [0%]
+- Require indentation for values of ternary expressions ([indent](https://eslint.org/docs/rules/indent)) [#927](https://github.com/standard/standard/issues/927) (4%)
+- Enforce newlines between operands of ternary expressions if the expression spans multiple lines ([multiline-ternary](https://eslint.org/docs/rules/multiline-ternary)) [#1558](https://github.com/standard/standard/issues/1558) (3%)
+- Disallow loops with a body that allows only one iteration ([no-unreachable-loop](https://eslint.org/docs/rules/no-unreachable-loop)) [#1556](https://github.com/standard/standard/issues/1556) (0%)
+- Disallow useless backreferences in regular expressions ([no-useless-backreference](https://eslint.org/docs/rules/no-useless-backreference)) [#1554](https://github.com/standard/standard/issues/1554) (0%)
+- Enforce default clauses in switch statements to be last ([default-case-last](https://eslint.org/docs/rules/default-case-last)) [#1553](https://github.com/standard/standard/issues/1553) (0%)
+- Disallow Number Literals That Lose Precision ([no-loss-of-precision](https://eslint.org/docs/rules/no-loss-of-precision)) [#1552](https://github.com/standard/standard/issues/1552) (0%)
 
 ### Changed rules
 
@@ -267,29 +267,29 @@ GitHub is matching donations, so your dollars go twice as far! 🚀
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Require Dot Notation Whenever Possible ([dot-notation](https://eslint.org/docs/rules/dot-notation)) [#1344](https://github.com/standard/standard/issues/1344) [6%]
-- Require consistent line breaks inside braces ([object-curly-newline](https://eslint.org/docs/rules/object-curly-newline)) [#782](https://github.com/standard/standard/issues/782) [1%]
-- Disallow template literals when placeholders or tagged template features are not used. ([quotes](https://eslint.org/docs/rules/quotes)) [#838](https://github.com/standard/standard/issues/838) [eslint-config-standard/#151](https://github.com/standard/eslint-config-standard/pull/151) [1%]
-- Disallow lexical declarations in case/default clauses ([no-case-declarations](https://eslint.org/docs/rules/no-case-declarations)) [#1211](https://github.com/standard/standard/issues/1211) [eslint-config-standard/#137](https://github.com/standard/eslint-config-standard/pull/137) [1%]
-- Require the first JSX property to be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties ([react/jsx-first-prop-new-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md)) [#696](https://github.com/standard/standard/issues/696) [1%]
-- Require linebreaks in curly braces in JSX attributes and expressions to be consistent ([react/jsx-curly-newline](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-newline.md)) [#1372](https://github.com/standard/standard/issues/1372) [1%]
-- Require JSX attributes and logical expressions to be indented correctly ([react/jsx-indent](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md)) [#1370](https://github.com/standard/standard/issues/1370) [1%]
-- Require JSX event handler names to follow conventions ([react/jsx-handler-names](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md)) [#1371](https://github.com/standard/standard/issues/1371) [1%]
-- Disallow spaces inside of curly braces in JSX expressions in children ([react/jsx-curly-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md)) [#1373](https://github.com/standard/standard/issues/1373) [1%]
-- Require JSX closing bracket to be aligned with the opening tag ([react/jsx-closing-bracket-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)) [#1361](https://github.com/standard/standard/issues/1361) [1%]
-- Disallow unnecessary curly braces in JSX props and children ([react/jsx-curly-brace-presence](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md)) [#1366](https://github.com/standard/standard/issues/1366) [1%]
-- Disallow missing `key` prop in JSX elements that likely require a `key` prop ([react/jsx-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)) [#1369](https://github.com/standard/standard/issues/1369) [1%]
-- Disallow import of modules using absolute paths ([import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)) [#861](https://github.com/standard/standard/issues/861) [#1343](https://github.com/standard/standard/issues/1343) [0%]
-- Require no spaces before JSX closing brackets ([react/jsx-tag-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md)) [#1348](https://github.com/standard/standard/issues/1348) [eslint-config-standard-jsx/38](https://github.com/standard/eslint-config-standard-jsx/pull/38) [0%]
-- Disallow multiple spaces between inline JSX props ([react/jsx-props-no-multi-spaces](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-multi-spaces.md)) [#1363](https://github.com/standard/standard/issues/1363) [0%]
-- Disallow accidental comments in JSX from being inserted as text nodes ([react/jsx-no-comment-textnodes](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md)) [#1368](https://github.com/standard/standard/issues/1368) [0%]
-- Prevent usage of unsafe `target='_blank'` in JSX links ([react/jsx-no-target-blank](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)) [#1367](https://github.com/standard/standard/issues/1367) [0%]
-- Require shorthand form for JSX fragments ([react/jsx-fragments](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md)) [#1364](https://github.com/standard/standard/issues/1364) [0%]
-- Require PascalCase for user-defined JSX components ([react/jsx-pascal-case](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)) [#1365](https://github.com/standard/standard/issues/1365) [0%]
-- Require JSX closing tag to be aligned with the opening tag ([react/jsx-closing-tag-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md)) [#1358](https://github.com/standard/standard/issues/1358) [0%]
-- Disallow missing parentheses around multiline JSX ([react/jsx-wrap-multilines](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)) [#710](https://github.com/standard/standard/issues/710) [0%]
-- Require pipeline operators to appear at the start of a line ([operator-linebreak](https://eslint.org/docs/rules/operator-linebreak)) [eslint-config-standard/#121](https://github.com/standard/eslint-config-standard/pull/121) [0%]
-- Disallow use of the void operator ([no-void](https://eslint.org/docs/rules/no-void)) [eslint-config-standard/#135](https://github.com/standard/eslint-config-standard/pull/135) [0%]
+- Require Dot Notation Whenever Possible ([dot-notation](https://eslint.org/docs/rules/dot-notation)) [#1344](https://github.com/standard/standard/issues/1344) (6%)
+- Require consistent line breaks inside braces ([object-curly-newline](https://eslint.org/docs/rules/object-curly-newline)) [#782](https://github.com/standard/standard/issues/782) (1%)
+- Disallow template literals when placeholders or tagged template features are not used. ([quotes](https://eslint.org/docs/rules/quotes)) [#838](https://github.com/standard/standard/issues/838) [eslint-config-standard/#151](https://github.com/standard/eslint-config-standard/pull/151) (1%)
+- Disallow lexical declarations in case/default clauses ([no-case-declarations](https://eslint.org/docs/rules/no-case-declarations)) [#1211](https://github.com/standard/standard/issues/1211) [eslint-config-standard/#137](https://github.com/standard/eslint-config-standard/pull/137) (1%)
+- Require the first JSX property to be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties ([react/jsx-first-prop-new-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md)) [#696](https://github.com/standard/standard/issues/696) (1%)
+- Require linebreaks in curly braces in JSX attributes and expressions to be consistent ([react/jsx-curly-newline](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-newline.md)) [#1372](https://github.com/standard/standard/issues/1372) (1%)
+- Require JSX attributes and logical expressions to be indented correctly ([react/jsx-indent](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md)) [#1370](https://github.com/standard/standard/issues/1370) (1%)
+- Require JSX event handler names to follow conventions ([react/jsx-handler-names](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md)) [#1371](https://github.com/standard/standard/issues/1371) (1%)
+- Disallow spaces inside of curly braces in JSX expressions in children ([react/jsx-curly-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md)) [#1373](https://github.com/standard/standard/issues/1373) (1%)
+- Require JSX closing bracket to be aligned with the opening tag ([react/jsx-closing-bracket-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)) [#1361](https://github.com/standard/standard/issues/1361) (1%)
+- Disallow unnecessary curly braces in JSX props and children ([react/jsx-curly-brace-presence](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md)) [#1366](https://github.com/standard/standard/issues/1366) (1%)
+- Disallow missing `key` prop in JSX elements that likely require a `key` prop ([react/jsx-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)) [#1369](https://github.com/standard/standard/issues/1369) (1%)
+- Disallow import of modules using absolute paths ([import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)) [#861](https://github.com/standard/standard/issues/861) [#1343](https://github.com/standard/standard/issues/1343) (0%)
+- Require no spaces before JSX closing brackets ([react/jsx-tag-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md)) [#1348](https://github.com/standard/standard/issues/1348) [eslint-config-standard-jsx/38](https://github.com/standard/eslint-config-standard-jsx/pull/38) (0%)
+- Disallow multiple spaces between inline JSX props ([react/jsx-props-no-multi-spaces](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-multi-spaces.md)) [#1363](https://github.com/standard/standard/issues/1363) (0%)
+- Disallow accidental comments in JSX from being inserted as text nodes ([react/jsx-no-comment-textnodes](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md)) [#1368](https://github.com/standard/standard/issues/1368) (0%)
+- Prevent usage of unsafe `target='_blank'` in JSX links ([react/jsx-no-target-blank](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)) [#1367](https://github.com/standard/standard/issues/1367) (0%)
+- Require shorthand form for JSX fragments ([react/jsx-fragments](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md)) [#1364](https://github.com/standard/standard/issues/1364) (0%)
+- Require PascalCase for user-defined JSX components ([react/jsx-pascal-case](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)) [#1365](https://github.com/standard/standard/issues/1365) (0%)
+- Require JSX closing tag to be aligned with the opening tag ([react/jsx-closing-tag-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md)) [#1358](https://github.com/standard/standard/issues/1358) (0%)
+- Disallow missing parentheses around multiline JSX ([react/jsx-wrap-multilines](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)) [#710](https://github.com/standard/standard/issues/710) (0%)
+- Require pipeline operators to appear at the start of a line ([operator-linebreak](https://eslint.org/docs/rules/operator-linebreak)) [eslint-config-standard/#121](https://github.com/standard/eslint-config-standard/pull/121) (0%)
+- Disallow use of the void operator ([no-void](https://eslint.org/docs/rules/no-void)) [eslint-config-standard/#135](https://github.com/standard/eslint-config-standard/pull/135) (0%)
 
 ### Changed rules
 
@@ -348,15 +348,15 @@ When you upgrade, consider running `standard --fix` to automatically format your
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Disallow spaces inside of array brackets ([array-bracket-spacing](https://eslint.org/docs/rules/array-bracket-spacing)) [#1203](https://github.com/standard/standard/issues/1203) [eslint-config-standard/#131](https://github.com/standard/eslint-config-standard/pull/131) [14%]
-- Require `const` instead of `let` if variable is never reassigned ([prefer-const](https://eslint.org/docs/rules/prefer-const)) [#523](https://github.com/standard/standard/issues/523) [eslint-config-standard/#133](https://github.com/standard/eslint-config-standard/pull/133) [14%]
-- Disallow quotes around object literal property names that are not strictly required ([quote-props](https://eslint.org/docs/rules/quote-props)) [#791](https://github.com/standard/standard/issues/791) [4%]
-- Disallow use of Object.prototypes builtins directly ([no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins)) [#1310](https://github.com/standard/standard/issues/1310) [3%]
-- Require an empty line between class members ([lines-between-class-members](https://eslint.org/docs/rules/lines-between-class-members)) [#438](https://github.com/standard/standard/issues/438) [1%]
-- Disallow using an async function as a Promise executor ([no-async-promise-executor](https://eslint.org/docs/rules/no-async-promise-executor)) [#1309](https://github.com/standard/standard/issues/1309) [1%]
-- Disallow spaces inside of computed properties ([computed-property-spacing](https://eslint.org/docs/rules/computed-property-spacing)) [#1315](https://github.com/standard/standard/issues/1315) [eslint-config-standard/#131](https://github.com/standard/eslint-config-standard/pull/131) [1%]
-- Disallow unnecessary catch clauses ([no-useless-catch](https://eslint.org/docs/rules/no-useless-catch)) [#1312](https://github.com/standard/standard/issues/1312) [0%]
-- Disallow characters which are made with multiple code points in character class syntax ([no-misleading-character-class](https://eslint.org/docs/rules/no-misleading-character-class)) [#1311](https://github.com/standard/standard/issues/1311) [0%]
+- Disallow spaces inside of array brackets ([array-bracket-spacing](https://eslint.org/docs/rules/array-bracket-spacing)) [#1203](https://github.com/standard/standard/issues/1203) [eslint-config-standard/#131](https://github.com/standard/eslint-config-standard/pull/131) (14%)
+- Require `const` instead of `let` if variable is never reassigned ([prefer-const](https://eslint.org/docs/rules/prefer-const)) [#523](https://github.com/standard/standard/issues/523) [eslint-config-standard/#133](https://github.com/standard/eslint-config-standard/pull/133) (14%)
+- Disallow quotes around object literal property names that are not strictly required ([quote-props](https://eslint.org/docs/rules/quote-props)) [#791](https://github.com/standard/standard/issues/791) (4%)
+- Disallow use of Object.prototypes builtins directly ([no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins)) [#1310](https://github.com/standard/standard/issues/1310) (3%)
+- Require an empty line between class members ([lines-between-class-members](https://eslint.org/docs/rules/lines-between-class-members)) [#438](https://github.com/standard/standard/issues/438) (1%)
+- Disallow using an async function as a Promise executor ([no-async-promise-executor](https://eslint.org/docs/rules/no-async-promise-executor)) [#1309](https://github.com/standard/standard/issues/1309) (1%)
+- Disallow spaces inside of computed properties ([computed-property-spacing](https://eslint.org/docs/rules/computed-property-spacing)) [#1315](https://github.com/standard/standard/issues/1315) [eslint-config-standard/#131](https://github.com/standard/eslint-config-standard/pull/131) (1%)
+- Disallow unnecessary catch clauses ([no-useless-catch](https://eslint.org/docs/rules/no-useless-catch)) [#1312](https://github.com/standard/standard/issues/1312) (0%)
+- Disallow characters which are made with multiple code points in character class syntax ([no-misleading-character-class](https://eslint.org/docs/rules/no-misleading-character-class)) [#1311](https://github.com/standard/standard/issues/1311) (0%)
 
 ## [12.0.1] - 2018-08-29
 
@@ -381,10 +381,10 @@ When you upgrade, consider running `standard --fix` to automatically format your
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Require spacing inside of braces ([object-curly-spacing](https://eslint.org/docs/rules/object-curly-spacing)) [#609](https://github.com/standard/standard/issues/609) [eslint-config-standard/#35](https://github.com/standard/eslint-config-standard/issues/35) [29%]
-- Disallow APIs that were deprecated in Node 10 ([no-deprecated-api](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-deprecated-api.md)) [#1164](https://github.com/standard/standard/pull/1164) [15%]
+- Require spacing inside of braces ([object-curly-spacing](https://eslint.org/docs/rules/object-curly-spacing)) [#609](https://github.com/standard/standard/issues/609) [eslint-config-standard/#35](https://github.com/standard/eslint-config-standard/issues/35) (29%)
+- Disallow APIs that were deprecated in Node 10 ([no-deprecated-api](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-deprecated-api.md)) [#1164](https://github.com/standard/standard/pull/1164) (15%)
   - e.g. `assert.equal()`, `assert.deepEqual()` and `assert.notEqual()` were deprecated in Node 10.
-- Disallow self assignment of properties ([no-self-assign](https://eslint.org/docs/rules/no-self-assign)) [#1186](https://github.com/standard/standard/issues/1186) [0%]
+- Disallow self assignment of properties ([no-self-assign](https://eslint.org/docs/rules/no-self-assign)) [#1186](https://github.com/standard/standard/issues/1186) (0%)
 - Disallow use of an exported name as the locally imported name of a default export ([import/no-named-as-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md)) [eslint-config-standard/#98](https://github.com/standard/eslint-config-standard/pull/98)
 
 ### Changed rules
@@ -498,20 +498,20 @@ the issues caught by this new version.
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Disallow using deprecated Node.js APIs ([node/no-deprecated-api](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-deprecated-api.md)) [#693](https://github.com/standard/standard/issues/693) [13%]
+- Disallow using deprecated Node.js APIs ([node/no-deprecated-api](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-deprecated-api.md)) [#693](https://github.com/standard/standard/issues/693) (13%)
   - Ensures that code always runs without warnings on the latest versions of Node.js
   - Ensures that safe Buffer methods (`Buffer.from()`, `Buffer.alloc()`) are used instead of `Buffer()`
-- Enforce callbacks always called with Node.js-style error first ([standard/no-callback-literal](https://github.com/xjamundx/eslint-plugin-standard#rules-explanations)) [#623](https://github.com/standard/standard/issues/623) [3%]
+- Enforce callbacks always called with Node.js-style error first ([standard/no-callback-literal](https://github.com/xjamundx/eslint-plugin-standard#rules-explanations)) [#623](https://github.com/standard/standard/issues/623) (3%)
   - Functions named `callback` or `cb` must be invoked with `null`, `undefined`, or an `Error` as the first argument
   - Disallows using a string instead of an `Error` object
   - Disallows confusing callbacks that do not follow the standard Node.js pattern
-- Disallow any imports that come after non-import statements ([import/first](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md)) [#806](https://github.com/standard/standard/issues/806) [1%]
-- Disallow unnecessary return await ([no-return-await](https://eslint.org/docs/rules/no-return-await)) [#695](https://github.com/standard/standard/issues/695) [0%]
-- Disallow comma-dangle in functions ([comma-dangle](https://eslint.org/docs/rules/comma-dangle)) [#787](https://github.com/standard/standard/issues/787) [0%]
-- Disallow repeated exports of names or defaults ([import/export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md)) [#806](https://github.com/standard/standard/issues/806) [0%]
-- Disallow import of modules using absolute paths ([import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)) [#806](https://github.com/standard/standard/issues/806) [0%]
-- Disallow Webpack loader syntax in imports ([import/no-webpack-loader-syntax](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)) [#806](https://github.com/standard/standard/issues/806) [0%]
-- Disallow comparing against -0 ([no-compare-neg-zero](https://eslint.org/docs/rules/no-compare-neg-zero)) [#812](https://github.com/standard/standard/issues/812) [0%]
+- Disallow any imports that come after non-import statements ([import/first](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md)) [#806](https://github.com/standard/standard/issues/806) (1%)
+- Disallow unnecessary return await ([no-return-await](https://eslint.org/docs/rules/no-return-await)) [#695](https://github.com/standard/standard/issues/695) (0%)
+- Disallow comma-dangle in functions ([comma-dangle](https://eslint.org/docs/rules/comma-dangle)) [#787](https://github.com/standard/standard/issues/787) (0%)
+- Disallow repeated exports of names or defaults ([import/export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md)) [#806](https://github.com/standard/standard/issues/806) (0%)
+- Disallow import of modules using absolute paths ([import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)) [#806](https://github.com/standard/standard/issues/806) (0%)
+- Disallow Webpack loader syntax in imports ([import/no-webpack-loader-syntax](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)) [#806](https://github.com/standard/standard/issues/806) (0%)
+- Disallow comparing against -0 ([no-compare-neg-zero](https://eslint.org/docs/rules/no-compare-neg-zero)) [#812](https://github.com/standard/standard/issues/812) (0%)
 
 ### Changed rules
 
@@ -565,19 +565,19 @@ your tests to improve their robustness. [Read about the changes you need to make
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Disallow mixing different operators without parens ([no-mixed-operators](https://eslint.org/docs/rules/no-mixed-operators)) [#566](https://github.com/standard/standard/issues/566) [5%]
-- Enforce 1 newline at end of file (previously 1 or 2 were ok) ([no-multiple-empty-lines](https://eslint.org/docs/rules/no-multiple-empty-lines)) [#733](https://github.com/standard/standard/issues/733) [3%]
-- Disallow Unused Expressions ([no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions)) [#690](https://github.com/standard/standard/issues/690) [3%]
+- Disallow mixing different operators without parens ([no-mixed-operators](https://eslint.org/docs/rules/no-mixed-operators)) [#566](https://github.com/standard/standard/issues/566) (5%)
+- Enforce 1 newline at end of file (previously 1 or 2 were ok) ([no-multiple-empty-lines](https://eslint.org/docs/rules/no-multiple-empty-lines)) [#733](https://github.com/standard/standard/issues/733) (3%)
+- Disallow Unused Expressions ([no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions)) [#690](https://github.com/standard/standard/issues/690) (3%)
   - Note: this affects users of the Chai test framework. [Read about the changes you need to make](https://github.com/standard/standard/issues/690#issuecomment-278533482).
-- Disallow redundant return statements ([no-useless-return](https://eslint.org/docs/rules/no-useless-return)) [#694](https://github.com/standard/standard/issues/694) [1%]
-- Disallow Incorrect Early Use ([no-use-before-define](https://eslint.org/docs/rules/no-use-before-define)) [#636](https://github.com/standard/standard/issues/636) [0%]
-- Enforce that Promise rejections are passed an Error object as a reason ([prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors)) [#777](https://github.com/standard/standard/issues/777) [0%]
-- Enforce comparing `typeof` expressions against string literals ([valid-typeof](https://eslint.org/docs/rules/valid-typeof)) [#629](https://github.com/standard/standard/issues/629) [0%]
-- Enforce spacing around \* in generator functions ([generator-star-spacing](https://eslint.org/docs/rules/generator-star-spacing)) [#724](https://github.com/standard/standard/issues/724) [0%]
-- Disallow Unnecessary Labels ([no-extra-label](https://eslint.org/docs/rules/no-extra-label)) [#736](https://github.com/standard/standard/issues/736) [0%]
-- Disallow spacing between template tags and their literals ([template-tag-spacing](https://eslint.org/docs/rules/template-tag-spacing)) [#755](https://github.com/standard/standard/issues/775) [0%]
-- Disallow padding within switch statements and classes ([padded-blocks](https://eslint.org/docs/rules/padded-blocks)) [#610](https://github.com/standard/standard/issues/610) [0%]
-- Enforce that Symbols are passed a description ([symbol-description](https://eslint.org/docs/rules/symbol-description)) [#630](https://github.com/standard/standard/issues/630) [0%]
+- Disallow redundant return statements ([no-useless-return](https://eslint.org/docs/rules/no-useless-return)) [#694](https://github.com/standard/standard/issues/694) (1%)
+- Disallow Incorrect Early Use ([no-use-before-define](https://eslint.org/docs/rules/no-use-before-define)) [#636](https://github.com/standard/standard/issues/636) (0%)
+- Enforce that Promise rejections are passed an Error object as a reason ([prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors)) [#777](https://github.com/standard/standard/issues/777) (0%)
+- Enforce comparing `typeof` expressions against string literals ([valid-typeof](https://eslint.org/docs/rules/valid-typeof)) [#629](https://github.com/standard/standard/issues/629) (0%)
+- Enforce spacing around \* in generator functions ([generator-star-spacing](https://eslint.org/docs/rules/generator-star-spacing)) [#724](https://github.com/standard/standard/issues/724) (0%)
+- Disallow Unnecessary Labels ([no-extra-label](https://eslint.org/docs/rules/no-extra-label)) [#736](https://github.com/standard/standard/issues/736) (0%)
+- Disallow spacing between template tags and their literals ([template-tag-spacing](https://eslint.org/docs/rules/template-tag-spacing)) [#755](https://github.com/standard/standard/issues/775) (0%)
+- Disallow padding within switch statements and classes ([padded-blocks](https://eslint.org/docs/rules/padded-blocks)) [#610](https://github.com/standard/standard/issues/610) (0%)
+- Enforce that Symbols are passed a description ([symbol-description](https://eslint.org/docs/rules/symbol-description)) [#630](https://github.com/standard/standard/issues/630) (0%)
 
 ### Changed rules
 
@@ -669,16 +669,16 @@ Full changelog below. Cheers!
 
 _(Estimated % of affected standard users, based on test suite in parens)_
 
-- Enforce placing object properties on separate lines ([object-property-newline](https://eslint.org/docs/rules/object-property-newline)) [#524](https://github.com/standard/standard/issues/524) [2%]
-- Require block comments to be balanced ([spaced-comment "balanced"](https://eslint.org/docs/rules/spaced-comment)) [#572](https://github.com/standard/standard/issues/572) [2%]
-- Disallow constant expressions in conditions ([no-constant-condition](https://eslint.org/docs/rules/no-constant-condition)) [#563](https://github.com/standard/standard/issues/563) [1%]
-- Disallow renaming import, export, and destructured assignments to the same name ([no-useless-rename](https://eslint.org/docs/rules/no-useless-rename)) [#537](https://github.com/standard/standard/issues/537) [0%]
-- Disallow spacing between rest and spread operators and their expressions ([rest-spread-spacing](https://eslint.org/docs/rules/rest-spread-spacing)) [#567](https://github.com/standard/standard/issues/567) [0%]
-- Disallow the Unicode Byte Order Mark (BOM) ([unicode-bom](https://eslint.org/docs/rules/unicode-bom)) [#538](https://github.com/standard/standard/issues/538) [0%]
-- Disallow assignment to native objects/global variables ([no-global-assign](https://eslint.org/docs/rules/no-global-assign)) [#596](https://github.com/standard/standard/issues/596) [0%]
-- Disallow negating the left operand of relational operators ([no-unsafe-negation](https://eslint.org/docs/rules/no-unsafe-negation)) [#595](https://github.com/standard/standard/issues/595) [0%]
-- Disallow template literal placeholder syntax in regular strings ([no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)) [#594](https://github.com/standard/standard/issues/594) [0%]
-- Disallow tabs in file ([no-tabs](https://eslint.org/docs/rules/no-tabs)) [#593](https://github.com/standard/standard/issues/593) [0%]
+- Enforce placing object properties on separate lines ([object-property-newline](https://eslint.org/docs/rules/object-property-newline)) [#524](https://github.com/standard/standard/issues/524) (2%)
+- Require block comments to be balanced ([spaced-comment "balanced"](https://eslint.org/docs/rules/spaced-comment)) [#572](https://github.com/standard/standard/issues/572) (2%)
+- Disallow constant expressions in conditions ([no-constant-condition](https://eslint.org/docs/rules/no-constant-condition)) [#563](https://github.com/standard/standard/issues/563) (1%)
+- Disallow renaming import, export, and destructured assignments to the same name ([no-useless-rename](https://eslint.org/docs/rules/no-useless-rename)) [#537](https://github.com/standard/standard/issues/537) (0%)
+- Disallow spacing between rest and spread operators and their expressions ([rest-spread-spacing](https://eslint.org/docs/rules/rest-spread-spacing)) [#567](https://github.com/standard/standard/issues/567) (0%)
+- Disallow the Unicode Byte Order Mark (BOM) ([unicode-bom](https://eslint.org/docs/rules/unicode-bom)) [#538](https://github.com/standard/standard/issues/538) (0%)
+- Disallow assignment to native objects/global variables ([no-global-assign](https://eslint.org/docs/rules/no-global-assign)) [#596](https://github.com/standard/standard/issues/596) (0%)
+- Disallow negating the left operand of relational operators ([no-unsafe-negation](https://eslint.org/docs/rules/no-unsafe-negation)) [#595](https://github.com/standard/standard/issues/595) (0%)
+- Disallow template literal placeholder syntax in regular strings ([no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)) [#594](https://github.com/standard/standard/issues/594) (0%)
+- Disallow tabs in file ([no-tabs](https://eslint.org/docs/rules/no-tabs)) [#593](https://github.com/standard/standard/issues/593) (0%)
 
 ### Changed rules
 
@@ -718,14 +718,14 @@ export * from 'bar'
 
 _Estimated % of affected standard users, based on test suite_
 
-- Require camelCase ([camelcase](https://eslint.org/docs/rules/camelcase)) [4%]
-- Disallow unnecessary escape usage ([no-useless-escape](https://eslint.org/docs/rules/no-useless-escape)) [4% -- but, including many bugs]
-- Disallow duplicate imports ([no-duplicate-imports](https://eslint.org/docs/rules/no-duplicate-imports)) [0%]
-- Disallow unmodified conditions of loops ([no-unmodified-loop-condition](https://eslint.org/docs/2.0.0/rules/no-unmodified-loop-condition)) [0%]
-- Disallow whitespace before properties ([no-whitespace-before-property](https://eslint.org/docs/2.0.0/rules/no-whitespace-before-property)) [0%]
-- Disallow control flow statements in `finally` blocks ([no-unsafe-finally](https://eslint.org/docs/rules/no-unsafe-finally)) [0%]
-- Disallow unnecessary computed property keys on objects ([no-useless-computed-key](https://eslint.org/docs/rules/no-useless-computed-key)) [0%]
-- Validate spacing before closing bracket in JSX ([react/jsx-space-before-closing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md)) [0%]
+- Require camelCase ([camelcase](https://eslint.org/docs/rules/camelcase)) (4%)
+- Disallow unnecessary escape usage ([no-useless-escape](https://eslint.org/docs/rules/no-useless-escape)) (4% -- but, including many bugs)
+- Disallow duplicate imports ([no-duplicate-imports](https://eslint.org/docs/rules/no-duplicate-imports)) (0%)
+- Disallow unmodified conditions of loops ([no-unmodified-loop-condition](https://eslint.org/docs/2.0.0/rules/no-unmodified-loop-condition)) (0%)
+- Disallow whitespace before properties ([no-whitespace-before-property](https://eslint.org/docs/2.0.0/rules/no-whitespace-before-property)) (0%)
+- Disallow control flow statements in `finally` blocks ([no-unsafe-finally](https://eslint.org/docs/rules/no-unsafe-finally)) (0%)
+- Disallow unnecessary computed property keys on objects ([no-useless-computed-key](https://eslint.org/docs/rules/no-useless-computed-key)) (0%)
+- Validate spacing before closing bracket in JSX ([react/jsx-space-before-closing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md)) (0%)
 
 ### Removed rules
 
@@ -786,23 +786,23 @@ The goal of this release is to make `standard` faster to install, and simpler t
 
 _The percentage (%) of users that rule changes will effect, based on real-world testing of the top ~400 npm packages is denoted in brackets._
 
-- Disallow `__dirname`/`__filename` string concatenation ([#403](https://github.com/standard/standard/issues/403)) ([no-path-concat](https://eslint.org/docs/2.0.0/rules/no-path-concat)) [5%]
-- Require parens in arrow function arguments ([#309](https://github.com/standard/standard/issues/309)) ([arrow-parens](https://eslint.org/docs/2.0.0/rules/arrow-parens.html)) [5%]
+- Disallow `__dirname`/`__filename` string concatenation ([#403](https://github.com/standard/standard/issues/403)) ([no-path-concat](https://eslint.org/docs/2.0.0/rules/no-path-concat)) (5%)
+- Require parens in arrow function arguments ([#309](https://github.com/standard/standard/issues/309)) ([arrow-parens](https://eslint.org/docs/2.0.0/rules/arrow-parens.html)) (5%)
 - Ensure that `new Promise()` is instantiated with the parameter names
-  `resolve`, `reject` ([#282](https://github.com/standard/standard/issues/282)) ([promise/param-names](https://github.com/xjamundx/eslint-plugin-promise#param-names)) [1%]
-- Enforce Usage of Spacing in Template Strings ([template-curly-spacing](https://eslint.org/docs/2.0.0/rules/template-curly-spacing)) [1%]
-- Template strings are only allowed when necessary, i.e. template string features are being used (eslint got stricter: [eslint/eslint#5147](https://github.com/eslint/eslint/issues/5147)) [1%]
-- Better dead code detection after conditional statements (eslint got stricter) [1%]
-- Enforce spaces around `*` in `yield * something` ([#335](https://github.com/standard/standard/issues/335)) ([yield-star-spacing](https://eslint.org/docs/2.0.0/rules/yield-star-spacing)) [0%]
-- Disallow labels on loops/switch statements too (made rule stricter) ([no-labels](https://eslint.org/docs/2.0.0/rules/no-labels.html)) [0%]
-- Disallow unnecessary constructor ([no-useless-constructor](https://eslint.org/docs/2.0.0/rules/no-useless-constructor)) [0%]
-- Disallow empty destructuring patterns ([no-empty-pattern](https://eslint.org/docs/2.0.0/rules/no-empty-pattern)) [0%]
-- Disallow Symbol Constructor ([no-new-symbol](https://eslint.org/docs/2.0.0/rules/no-new-symbol)) [0%]
-- Disallow Self Assignment ([no-self-assign](https://eslint.org/docs/2.0.0/rules/no-self-assign)) [0%]
+  `resolve`, `reject` ([#282](https://github.com/standard/standard/issues/282)) ([promise/param-names](https://github.com/xjamundx/eslint-plugin-promise#param-names)) (1%)
+- Enforce Usage of Spacing in Template Strings ([template-curly-spacing](https://eslint.org/docs/2.0.0/rules/template-curly-spacing)) (1%)
+- Template strings are only allowed when necessary, i.e. template string features are being used (eslint got stricter: [eslint/eslint#5147](https://github.com/eslint/eslint/issues/5147)) (1%)
+- Better dead code detection after conditional statements (eslint got stricter) (1%)
+- Enforce spaces around `*` in `yield * something` ([#335](https://github.com/standard/standard/issues/335)) ([yield-star-spacing](https://eslint.org/docs/2.0.0/rules/yield-star-spacing)) (0%)
+- Disallow labels on loops/switch statements too (made rule stricter) ([no-labels](https://eslint.org/docs/2.0.0/rules/no-labels.html)) (0%)
+- Disallow unnecessary constructor ([no-useless-constructor](https://eslint.org/docs/2.0.0/rules/no-useless-constructor)) (0%)
+- Disallow empty destructuring patterns ([no-empty-pattern](https://eslint.org/docs/2.0.0/rules/no-empty-pattern)) (0%)
+- Disallow Symbol Constructor ([no-new-symbol](https://eslint.org/docs/2.0.0/rules/no-new-symbol)) (0%)
+- Disallow Self Assignment ([no-self-assign](https://eslint.org/docs/2.0.0/rules/no-self-assign)) (0%)
 
 ### Removed Rules
 
-- `parseInt()` radix rule because ES5 fixes this issue ([#384](https://github.com/standard/standard/issues/384)) ([radix](https://eslint.org/docs/2.0.0/rules/radix.html)) [0%]
+- `parseInt()` radix rule because ES5 fixes this issue ([#384](https://github.com/standard/standard/issues/384)) ([radix](https://eslint.org/docs/2.0.0/rules/radix.html)) (0%)
 
 ### Expose eslint configuration via command line options and `package.json`
 

--- a/README.md
+++ b/README.md
@@ -46,31 +46,49 @@ Give it a try by running `npx standard --fix` right now!
 
 ## Table of Contents
 
-- Quick start
-  - [Install](#install)
-  - [Usage](#usage)
-  - [What you might do if you're clever](#what-you-might-do-if-youre-clever)
-- FAQ
-  - [Why should I use JavaScript Standard Style?](#why-should-i-use-javascript-standard-style)
-  - [Who uses JavaScript Standard Style?](#who-uses-javascript-standard-style)
-  - [Are there text editor plugins?](#are-there-text-editor-plugins)
-  - [Is there a readme badge?](#is-there-a-readme-badge)
-  - [I disagree with rule X, can you change it?](#i-disagree-with-rule-x-can-you-change-it)
-  - [But this isn't a real web standard!](#but-this-isnt-a-real-web-standard)
-  - [Is there an automatic formatter?](#is-there-an-automatic-formatter)
-  - [How do I ignore files?](#how-do-i-ignore-files)
-  - [How do I disable a rule?](#how-do-i-disable-a-rule)
-  - [I use a library that pollutes the global namespace. How do I prevent "variable is not defined" errors?](#i-use-a-library-that-pollutes-the-global-namespace-how-do-i-prevent-variable-is-not-defined-errors)
-  - [How do I use experimental JavaScript (ES Next) features?](#how-do-i-use-experimental-javascript-es-next-features)
-  - [Can I use a JavaScript language variant, like Flow or TypeScript?](#can-i-use-a-javascript-language-variant-like-flow-or-typescript)
-  - [What about Mocha, Jest, Jasmine, QUnit, etc?](#what-about-mocha-jest-jasmine-qunit-etc)
-  - [What about Web Workers and Service Workers?](#what-about-web-workers-and-service-workers)
-  - [What is the difference between warnings and errors?](#what-is-the-difference-between-warnings-and-errors)
-  - [Can I check code inside of Markdown or HTML files?](#can-i-check-code-inside-of-markdown-or-html-files)
-  - [Is there a Git `pre-commit` hook?](#is-there-a-git-pre-commit-hook)
-  - [How do I make the output all colorful and pretty?](#how-do-i-make-the-output-all-colorful-and-pretty)
-  - [Is there a Node.js API?](#is-there-a-nodejs-api)
-  - [How do I contribute to StandardJS?](#how-do-i-contribute-to-standardjs)
+<details><summary>Click to expand</summary>
+
+- [Install](#install)
+- [Usage](#usage)
+- [What you might do if you're clever](#what-you-might-do-if-youre-clever)
+- [Why should I use JavaScript Standard Style?](#why-should-i-use-javascript-standard-style)
+- [Who uses JavaScript Standard Style?](#who-uses-javascript-standard-style)
+- [Are there text editor plugins?](#are-there-text-editor-plugins)
+  - [Sublime Text](#sublime-text)
+  - [Atom](#atom)
+  - [Visual Studio Code](#visual-studio-code)
+  - [Vim](#vim)
+  - [Emacs](#emacs)
+  - [Brackets](#brackets)
+  - [WebStorm (PhpStorm, IntelliJ, RubyMine, JetBrains, etc.)](#webstorm-phpstorm-intellij-rubymine-jetbrains-etc)
+- [Is there a readme badge?](#is-there-a-readme-badge)
+- [I disagree with rule X, can you change it?](#i-disagree-with-rule-x-can-you-change-it)
+- [But this isn't a real web standard!](#but-this-isnt-a-real-web-standard)
+- [Is there an automatic formatter?](#is-there-an-automatic-formatter)
+- [How do I ignore files?](#how-do-i-ignore-files)
+- [How do I disable a rule?](#how-do-i-disable-a-rule)
+- [I use a library that pollutes the global namespace. How do I prevent "variable is not defined" errors?](#i-use-a-library-that-pollutes-the-global-namespace-how-do-i-prevent-variable-is-not-defined-errors)
+- [How do I use experimental JavaScript (ES Next) features?](#how-do-i-use-experimental-javascript-es-next-features)
+- [Can I use a JavaScript language variant, like Flow or TypeScript?](#can-i-use-a-javascript-language-variant-like-flow-or-typescript)
+  - [Flow](#flow)
+  - [TypeScript](#typescript)
+- [What about Mocha, Jest, Jasmine, QUnit, etc?](#what-about-mocha-jest-jasmine-qunit-etc)
+- [What about Web Workers and Service Workers?](#what-about-web-workers-and-service-workers)
+- [What is the difference between warnings and errors?](#what-is-the-difference-between-warnings-and-errors)
+- [Can I check code inside of Markdown or HTML files?](#can-i-check-code-inside-of-markdown-or-html-files)
+- [Is there a Git `pre-commit` hook?](#is-there-a-git-pre-commit-hook)
+  - [Install your own hook](#install-your-own-hook)
+  - [Use a `pre-commit` hook](#use-a-pre-commit-hook)
+- [How do I make the output all colorful and pretty?](#how-do-i-make-the-output-all-colorful-and-pretty)
+- [Is there a Node.js API?](#is-there-a-nodejs-api)
+  - [`standard.lintText(text, [opts], callback)`](#standardlinttexttext-opts-callback)
+  - [`results = standard.lintTextSync(text, [opts])`](#results--standardlinttextsynctext-opts)
+  - [`standard.lintFiles(files, [opts], callback)`](#standardlintfilesfiles-opts-callback)
+- [How do I contribute to StandardJS?](#how-do-i-contribute-to-standardjs)
+- [Security Policies and Procedures](#security-policies-and-procedures)
+- [License](#license)
+
+</details>
 
 ## Install
 
@@ -87,7 +105,7 @@ Or, you can install `standard` locally, for use in a single project:
 $ npm install standard --save-dev
 ```
 
-*Note: To run the preceding commands, [Node.js](http://nodejs.org) and [npm](https://npmjs.com) must be installed.*
+_Note: To run the preceding commands, [Node.js](http://nodejs.org) and [npm](https://npmjs.com) must be installed._
 
 ## Usage
 
@@ -172,47 +190,44 @@ to `standard`.
 
 ## Who uses JavaScript Standard Style?
 
-[<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/nodejs.png>](https://nodejs.org) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/npm.png>](https://www.npmjs.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/github.png>](https://github.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/elastic.png>](https://www.elastic.co) |
-|---|---|---|---|
+| [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/nodejs.png>](https://nodejs.org) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/npm.png>](https://www.npmjs.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/github.png>](https://github.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/elastic.png>](https://www.elastic.co) |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 
-[<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/express.png>](http://expressjs.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/electron.png>](http://electron.atom.io) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/nuxtjs.png>](https://nuxtjs.org/) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/atom.png>](https://atom.io) |
-|---|---|---|---|
+| [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/express.png>](http://expressjs.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/electron.png>](http://electron.atom.io) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/nuxtjs.png>](https://nuxtjs.org/) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/atom.png>](https://atom.io) |
+| ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/mongodb.jpg>](https://www.mongodb.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/zendesk.png>](https://www.zendesk.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/brave.png>](https://www.brave.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/zeit.png>](https://zeit.co) |
-|---|---|---|---|
+| --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/nodesource.png>](https://nodesource.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/nearform.png>](http://www.nearform.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/typeform.png>](https://www.typeform.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/gov-uk.png>](https://gds.blog.gov.uk) |
-|---|---|---|---|
+| ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/heroku.png>](https://www.heroku.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/saucelabs.png>](https://saucelabs.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/automattic.png>](https://automattic.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/godaddy.png>](https://www.godaddy.com) |
-|---|---|---|---|
+| ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/webtorrent.png>](https://webtorrent.io) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/ipfs.png>](https://ipfs.io) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/dat.png>](https://datproject.org) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/bitcoinjs.png>](https://bitcoinjs.org) |
-|---|---|---|---|
+| ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/voltra.png>](https://voltra.co) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/treasuredata.png>](https://www.treasuredata.com) | [<img alt="Free MIDIs, MIDI file downloads" width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/bitmidi.png>](https://bitmidi.com) | [<img width=190 alt="College essays, AP notes" src=https://cdn.rawgit.com/standard/standard/master/docs/logos/studynotes.jpg>](https://www.apstudynotes.org) |
-|---|---|---|---|
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/optiopay.png>](https://www.optiopay.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/jaguar-landrover.png>](https://www.jlrtechincubator.com/jlrti/) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/bustle.jpg>](https://www.bustle.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/zentrick.png>](https://www.zentrick.com) |
-|---|---|---|---|
+| ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/greenkeeper.png>](https://greenkeeper.io) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/karma.png>](https://karma-runner.github.io) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/taser.png>](https://www.taser.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/neo4j.png>](https://www.neo4j.com) |
-|---|---|---|---|
+| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/rentograph.png>](https://rentograph.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/eaze.png>](https://www.eaze.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/ctrl-alt-deseat.png>](https://www.ctrlaltdeseat.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/clevertech.png>](https://clevertech.biz) |
-|---|---|---|---|
+| ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/aragon.png>](https://aragon.org) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/flowsent.png>](https://www.flowsent.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/puma-browser.png>](https://www.pumabrowser.com/) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/webstorm.png>](https://www.jetbrains.com/webstorm/) |
-|---|---|---|---|
-
+| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/fastify.png>](https://www.fastify.io) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/scuttlebutt.png>](https://www.scuttlebutt.nz) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/solid.png>](https://solid.inrupt.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/grab.png>](https://www.grab.com) |
-|---|---|---|---|
-
+| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/jublia.png>](https://jublia.com/) | Your logo here | Your logo here | Your logo here |
-|---|---|---|---|
-
+| ---------------------------------------------------------------------------------------------------------------- | -------------- | -------------- | -------------- |
 
 In addition to companies, many community members use `standard` on packages that
 are [too numerous](https://raw.githubusercontent.com/standard/standard-packages/master/all.json)
@@ -233,8 +248,11 @@ Using **[Package Control][sublime-1]**, install **[SublimeLinter][sublime-2]** a
 For automatic formatting on save, install **[StandardFormat][sublime-4]**.
 
 [sublime-1]: https://packagecontrol.io/
+
 [sublime-2]: http://www.sublimelinter.com/en/latest/
+
 [sublime-3]: https://packagecontrol.io/packages/SublimeLinter-contrib-standard
+
 [sublime-4]: https://packagecontrol.io/packages/StandardFormat
 
 ### Atom
@@ -250,9 +268,13 @@ For automatic formatting, install **[standard-formatter][atom-2]**. For snippets
 install **[standardjs-snippets][atom-3]**.
 
 [atom-1]: https://atom.io/packages/linter-js-standard
+
 [atom-2]: https://atom.io/packages/standard-formatter
+
 [atom-3]: https://atom.io/packages/standardjs-snippets
+
 [atom-4]: https://atom.io/packages/linter-js-standard-engine
+
 [atom-5]: https://github.com/standard/standard-engine
 
 ### Visual Studio Code
@@ -262,7 +284,9 @@ Install **[vscode-standardjs][vscode-1]**. (Includes support for automatic forma
 For JS snippets, install: **[vscode-standardjs-snippets][vscode-2]**. For React snippets, install **[vscode-react-standard][vscode-3]**.
 
 [vscode-1]: https://marketplace.visualstudio.com/items/chenxsan.vscode-standardjs
+
 [vscode-2]: https://marketplace.visualstudio.com/items?itemName=capaj.vscode-standardjs-snippets
+
 [vscode-3]: https://marketplace.visualstudio.com/items/TimonVS.ReactSnippetsStandard
 
 ### Vim
@@ -277,16 +301,18 @@ let g:ale_fixers = {'javascript': ['standard']}
 ```
 
 This sets standard as your only linter and fixer for javascript files and so prevents conflicts with eslint. For linting and automatic fixing on save, add these lines to `.vimrc`:
+
 ```vim
 let g:ale_lint_on_save = 1
 let g:ale_fix_on_save = 1
 ```
 
-
 Alternative plugins to consider include [neomake][vim-2] and [syntastic][vim-3], both of which have built-in support for `standard` (though configuration may be necessary).
 
 [vim-1]: https://github.com/w0rp/ale
+
 [vim-2]: https://github.com/neomake/neomake
+
 [vim-3]: https://github.com/vim-syntastic/syntastic
 
 ### Emacs
@@ -295,6 +321,7 @@ Install **[Flycheck][emacs-1]** and check out the **[manual][emacs-2]** to learn
 how to enable it in your projects.
 
 [emacs-1]: http://www.flycheck.org
+
 [emacs-2]: http://www.flycheck.org/en/latest/user/installation.html
 
 ### Brackets
@@ -340,6 +367,7 @@ something' opinions. Hopefully, users see the value in that over defending their
 own opinions.
 
 There are a couple of similar packages for anyone who does not want to completely accept `standard`:
+
 - [semistandard](https://github.com/standard/semistandard) - standard, with semicolons
 - [standardx](https://github.com/standard/standardx) - standard, with custom tweaks
 
@@ -363,8 +391,8 @@ standards groups, which is why this repo is called `standard/standard` and not
 
 The word "standard" has more meanings than just "web standard" :-) For example:
 
-- This module helps hold our code to a high *standard of quality*.
-- This module ensures that new contributors follow some basic *style standards*.
+- This module helps hold our code to a high _standard of quality_.
+- This module ensures that new contributors follow some basic _style standards_.
 
 ## Is there an automatic formatter?
 
@@ -469,7 +497,7 @@ Or, add this to `package.json`:
 }
 ```
 
-*Note: `global` and `globals` are equivalent.*
+_Note: `global` and `globals` are equivalent._
 
 ## How do I use experimental JavaScript (ES Next) features?
 
@@ -537,7 +565,7 @@ Or, add this to `package.json`:
 }
 ```
 
-*Note: `plugin` and `plugins` are equivalent.*
+_Note: `plugin` and `plugins` are equivalent._
 
 ### TypeScript
 
@@ -574,7 +602,7 @@ check the
 [globals](https://github.com/sindresorhus/globals/blob/master/globals.json) npm
 module.
 
-*Note: `env` and `envs` are equivalent.*
+_Note: `env` and `envs` are equivalent._
 
 ## What about Web Workers and Service Workers?
 
@@ -679,6 +707,7 @@ fi
 The [pre-commit](https://pre-commit.com/) library allows hooks to be declared within a `.pre-commit-config.yaml` configuration file in the repo, and therefore more easily maintained across a team.
 
 Users of pre-commit can simply add `standard` to their `.pre-commit-config.yaml` file, which will automatically fix `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs` and `.cjs` files:
+
 ```yaml
   - repo: https://github.com/standard/standard
     rev: master
@@ -687,6 +716,7 @@ Users of pre-commit can simply add `standard` to their `.pre-commit-config.yaml`
 ```
 
 Alternatively, for more advanced styling configurations, use `standard` within the [eslint hook](https://github.com/pre-commit/mirrors-eslint):
+
 ```yaml
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: master
@@ -802,7 +832,7 @@ Here are some important packages in the `standard` ecosystem:
   - **[eslint-config-standard-jsx](https://github.com/standard/eslint-config-standard-jsx)** - eslint rules for standard (JSX)
   - **[eslint](https://github.com/eslint/eslint)** - the linter that powers standard
 - **[snazzy](https://github.com/standard/snazzy)** - pretty terminal output for standard
-- **[standard-www](https://github.com/standard/standard-www)** - code for https://standardjs.com
+- **[standard-www](https://github.com/standard/standard-www)** - code for <https://standardjs.com>
 - **[semistandard](https://github.com/standard/semistandard)** - standard, with semicolons (if you must)
 - **[standardx](https://github.com/standard/standardx)** - standard, with custom tweaks
 

--- a/README.md
+++ b/README.md
@@ -48,49 +48,53 @@ Give it a try by running `npx standard --fix` right now!
 
 <details><summary>Click to expand</summary>
 
-- [Install](#install)
-- [Usage](#usage)
-- [What you might do if you're clever](#what-you-might-do-if-youre-clever)
-- [Why should I use JavaScript Standard Style?](#why-should-i-use-javascript-standard-style)
-- [Who uses JavaScript Standard Style?](#who-uses-javascript-standard-style)
-- [Are there text editor plugins?](#are-there-text-editor-plugins)
-  - [Sublime Text](#sublime-text)
-  - [Atom](#atom)
-  - [Visual Studio Code](#visual-studio-code)
-  - [Vim](#vim)
-  - [Emacs](#emacs)
-  - [Brackets](#brackets)
-  - [WebStorm (PhpStorm, IntelliJ, RubyMine, JetBrains, etc.)](#webstorm-phpstorm-intellij-rubymine-jetbrains-etc)
-- [Is there a readme badge?](#is-there-a-readme-badge)
-- [I disagree with rule X, can you change it?](#i-disagree-with-rule-x-can-you-change-it)
-- [But this isn't a real web standard!](#but-this-isnt-a-real-web-standard)
-- [Is there an automatic formatter?](#is-there-an-automatic-formatter)
-- [How do I ignore files?](#how-do-i-ignore-files)
-- [How do I disable a rule?](#how-do-i-disable-a-rule)
-- [I use a library that pollutes the global namespace. How do I prevent "variable is not defined" errors?](#i-use-a-library-that-pollutes-the-global-namespace-how-do-i-prevent-variable-is-not-defined-errors)
-- [How do I use experimental JavaScript (ES Next) features?](#how-do-i-use-experimental-javascript-es-next-features)
-- [Can I use a JavaScript language variant, like Flow or TypeScript?](#can-i-use-a-javascript-language-variant-like-flow-or-typescript)
-  - [Flow](#flow)
-  - [TypeScript](#typescript)
-- [What about Mocha, Jest, Jasmine, QUnit, etc?](#what-about-mocha-jest-jasmine-qunit-etc)
-- [What about Web Workers and Service Workers?](#what-about-web-workers-and-service-workers)
-- [What is the difference between warnings and errors?](#what-is-the-difference-between-warnings-and-errors)
-- [Can I check code inside of Markdown or HTML files?](#can-i-check-code-inside-of-markdown-or-html-files)
-- [Is there a Git `pre-commit` hook?](#is-there-a-git-pre-commit-hook)
-  - [Install your own hook](#install-your-own-hook)
-  - [Use a `pre-commit` hook](#use-a-pre-commit-hook)
-- [How do I make the output all colorful and pretty?](#how-do-i-make-the-output-all-colorful-and-pretty)
-- [Is there a Node.js API?](#is-there-a-nodejs-api)
-  - [`standard.lintText(text, [opts], callback)`](#standardlinttexttext-opts-callback)
-  - [`results = standard.lintTextSync(text, [opts])`](#results--standardlinttextsynctext-opts)
-  - [`standard.lintFiles(files, [opts], callback)`](#standardlintfilesfiles-opts-callback)
-- [How do I contribute to StandardJS?](#how-do-i-contribute-to-standardjs)
+- [Quick start](#quick-start)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [What you might do if you're clever](#what-you-might-do-if-youre-clever)
+- [FAQ](#faq)
+  - [Why should I use JavaScript Standard Style?](#why-should-i-use-javascript-standard-style)
+  - [Who uses JavaScript Standard Style?](#who-uses-javascript-standard-style)
+  - [Are there text editor plugins?](#are-there-text-editor-plugins)
+    - [Sublime Text](#sublime-text)
+    - [Atom](#atom)
+    - [Visual Studio Code](#visual-studio-code)
+    - [Vim](#vim)
+    - [Emacs](#emacs)
+    - [Brackets](#brackets)
+    - [WebStorm (PhpStorm, IntelliJ, RubyMine, JetBrains, etc.)](#webstorm-phpstorm-intellij-rubymine-jetbrains-etc)
+  - [Is there a readme badge?](#is-there-a-readme-badge)
+  - [I disagree with rule X, can you change it?](#i-disagree-with-rule-x-can-you-change-it)
+  - [But this isn't a real web standard!](#but-this-isnt-a-real-web-standard)
+  - [Is there an automatic formatter?](#is-there-an-automatic-formatter)
+  - [How do I ignore files?](#how-do-i-ignore-files)
+  - [How do I disable a rule?](#how-do-i-disable-a-rule)
+  - [I use a library that pollutes the global namespace. How do I prevent "variable is not defined" errors?](#i-use-a-library-that-pollutes-the-global-namespace-how-do-i-prevent-variable-is-not-defined-errors)
+  - [How do I use experimental JavaScript (ES Next) features?](#how-do-i-use-experimental-javascript-es-next-features)
+  - [Can I use a JavaScript language variant, like Flow or TypeScript?](#can-i-use-a-javascript-language-variant-like-flow-or-typescript)
+    - [Flow](#flow)
+    - [TypeScript](#typescript)
+  - [What about Mocha, Jest, Jasmine, QUnit, etc?](#what-about-mocha-jest-jasmine-qunit-etc)
+  - [What about Web Workers and Service Workers?](#what-about-web-workers-and-service-workers)
+  - [What is the difference between warnings and errors?](#what-is-the-difference-between-warnings-and-errors)
+  - [Can I check code inside of Markdown or HTML files?](#can-i-check-code-inside-of-markdown-or-html-files)
+  - [Is there a Git `pre-commit` hook?](#is-there-a-git-pre-commit-hook)
+    - [Install your own hook](#install-your-own-hook)
+    - [Use a `pre-commit` hook](#use-a-pre-commit-hook)
+  - [How do I make the output all colorful and pretty?](#how-do-i-make-the-output-all-colorful-and-pretty)
+  - [Is there a Node.js API?](#is-there-a-nodejs-api)
+    - [`standard.lintText(text, [opts], callback)`](#standardlinttexttext-opts-callback)
+    - [`results = standard.lintTextSync(text, [opts])`](#results--standardlinttextsynctext-opts)
+    - [`standard.lintFiles(files, [opts], callback)`](#standardlintfilesfiles-opts-callback)
+  - [How do I contribute to StandardJS?](#how-do-i-contribute-to-standardjs)
 - [Security Policies and Procedures](#security-policies-and-procedures)
 - [License](#license)
 
 </details>
 
-## Install
+## Quick start
+
+### Install
 
 The easiest way to use JavaScript Standard Style is to install it globally as a
 Node command line program. Run the following command in Terminal:
@@ -107,7 +111,7 @@ $ npm install standard --save-dev
 
 _Note: To run the preceding commands, [Node.js](http://nodejs.org) and [npm](https://npmjs.com) must be installed._
 
-## Usage
+### Usage
 
 After you've installed `standard`, you should be able to use the `standard` program. The
 simplest use case would be checking the style of all JavaScript files in the
@@ -136,7 +140,7 @@ $ standard "src/util/**/*.js" "test/**/*.js"
 **Note:** by default `standard` will look for all files matching the patterns:
 `**/*.js`, `**/*.jsx`.
 
-## What you might do if you're clever
+### What you might do if you're clever
 
 1. Add it to `package.json`
 
@@ -162,7 +166,9 @@ $ standard "src/util/**/*.js" "test/**/*.js"
 
 3. Never give style feedback on a pull request again!
 
-## Why should I use JavaScript Standard Style?
+## FAQ
+
+### Why should I use JavaScript Standard Style?
 
 The beauty of JavaScript Standard Style is that it's simple. No one wants to
 maintain multiple hundred-line style configuration files for every module/project
@@ -188,7 +194,7 @@ ESLint"](https://www.youtube.com/watch?v=kuHfMw8j4xk). In this talk, you'll lear
 about linting, when to use `standard` versus `eslint`, and how `prettier` compares
 to `standard`.
 
-## Who uses JavaScript Standard Style?
+### Who uses JavaScript Standard Style?
 
 | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/nodejs.png>](https://nodejs.org) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/npm.png>](https://www.npmjs.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/github.png>](https://github.com) | [<img width=190 src=https://cdn.rawgit.com/standard/standard/master/docs/logos/elastic.png>](https://www.elastic.co) |
 | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -236,11 +242,11 @@ to list here.
 `standard` is also the top-starred linter in GitHub's
 [Clean Code Linter](https://github.com/showcases/clean-code-linters) showcase.
 
-## Are there text editor plugins?
+### Are there text editor plugins?
 
 First, install `standard`. Then, install the appropriate plugin for your editor:
 
-### Sublime Text
+#### Sublime Text
 
 Using **[Package Control][sublime-1]**, install **[SublimeLinter][sublime-2]** and
 **[SublimeLinter-contrib-standard][sublime-3]**.
@@ -255,7 +261,7 @@ For automatic formatting on save, install **[StandardFormat][sublime-4]**.
 
 [sublime-4]: https://packagecontrol.io/packages/StandardFormat
 
-### Atom
+#### Atom
 
 Install **[linter-js-standard][atom-1]**.
 
@@ -277,7 +283,7 @@ install **[standardjs-snippets][atom-3]**.
 
 [atom-5]: https://github.com/standard/standard-engine
 
-### Visual Studio Code
+#### Visual Studio Code
 
 Install **[vscode-standardjs][vscode-1]**. (Includes support for automatic formatting.)
 
@@ -289,7 +295,7 @@ For JS snippets, install: **[vscode-standardjs-snippets][vscode-2]**. For React 
 
 [vscode-3]: https://marketplace.visualstudio.com/items/TimonVS.ReactSnippetsStandard
 
-### Vim
+#### Vim
 
 Install **[ale][vim-1]**. And add these lines to your `.vimrc` file.
 
@@ -315,7 +321,7 @@ Alternative plugins to consider include [neomake][vim-2] and [syntastic][vim-3],
 
 [vim-3]: https://github.com/vim-syntastic/syntastic
 
-### Emacs
+#### Emacs
 
 Install **[Flycheck][emacs-1]** and check out the **[manual][emacs-2]** to learn
 how to enable it in your projects.
@@ -324,13 +330,13 @@ how to enable it in your projects.
 
 [emacs-2]: http://www.flycheck.org/en/latest/user/installation.html
 
-### Brackets
+#### Brackets
 
 Search the extension registry for **["Standard Code Style"][brackets-1]** and click "Install".
 
 [brackets-1]: https://github.com/ishamf/brackets-standard/
 
-### WebStorm (PhpStorm, IntelliJ, RubyMine, JetBrains, etc.)
+#### WebStorm (PhpStorm, IntelliJ, RubyMine, JetBrains, etc.)
 
 WebStorm [recently announced native support](https://blog.jetbrains.com/webstorm/2017/01/webstorm-2017-1-eap-171-2272/)
 for `standard` directly in the IDE.
@@ -339,7 +345,7 @@ If you still prefer to configure `standard` manually, [follow this guide][websto
 
 [webstorm-1]: docs/webstorm.md
 
-## Is there a readme badge?
+### Is there a readme badge?
 
 Yes! If you use `standard` in your project, you can include one of these badges in
 your readme to let people know that your code is using the standard style.
@@ -356,7 +362,7 @@ your readme to let people know that your code is using the standard style.
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 ```
 
-## I disagree with rule X, can you change it?
+### I disagree with rule X, can you change it?
 
 No. The whole point of `standard` is to save you time by avoiding
 [bikeshedding][bikeshedding] about code style. There are lots of debates online about
@@ -383,7 +389,7 @@ could spend your time solving! :P
 
 [bikeshedding]: https://www.freebsd.org/doc/en/books/faq/misc.html#bikeshed-painting
 
-## But this isn't a real web standard!
+### But this isn't a real web standard!
 
 Of course it's not! The style laid out here is not affiliated with any official web
 standards groups, which is why this repo is called `standard/standard` and not
@@ -394,7 +400,7 @@ The word "standard" has more meanings than just "web standard" :-) For example:
 - This module helps hold our code to a high _standard of quality_.
 - This module ensures that new contributors follow some basic _style standards_.
 
-## Is there an automatic formatter?
+### Is there an automatic formatter?
 
 Yes! You can use `standard --fix` to fix most issues automatically.
 
@@ -406,7 +412,7 @@ To save you time, `standard` outputs the message "`Run standard --fix to
 automatically fix some problems`" when it detects problems that can be fixed
 automatically.
 
-## How do I ignore files?
+### How do I ignore files?
 
 Certain paths (`node_modules/`, `coverage/`, `vendor/`, `*.min.js`,
 and files/folders that begin with `.` like `.git/`) are automatically ignored.
@@ -427,7 +433,7 @@ that, add a `standard.ignore` property to `package.json`:
 }
 ```
 
-## How do I disable a rule?
+### How do I disable a rule?
 
 In rare cases, you'll need to break a rule and hide the error generated by
 `standard`.
@@ -465,7 +471,7 @@ console.log('offending code goes here...')
 /* eslint-enable no-use-before-define */
 ```
 
-## I use a library that pollutes the global namespace. How do I prevent "variable is not defined" errors?
+### I use a library that pollutes the global namespace. How do I prevent "variable is not defined" errors?
 
 Some packages (e.g. `mocha`) put their functions (e.g. `describe`, `it`) on the
 global object (poor form!). Since these functions are not defined or `require`'d
@@ -499,7 +505,7 @@ Or, add this to `package.json`:
 
 _Note: `global` and `globals` are equivalent._
 
-## How do I use experimental JavaScript (ES Next) features?
+### How do I use experimental JavaScript (ES Next) features?
 
 `standard` supports the latest ECMAScript features, ES8 (ES2017), including
 language feature proposals that are in "Stage 4" of the proposal process.
@@ -530,7 +536,7 @@ Or, add this to `package.json`:
 }
 ```
 
-## Can I use a JavaScript language variant, like Flow or TypeScript?
+### Can I use a JavaScript language variant, like Flow or TypeScript?
 
 `standard` supports the latest ECMAScript features. However, Flow and TypeScript add new
 syntax to the language, so they are not supported out-of-the-box.
@@ -539,7 +545,7 @@ To support JavaScript language variants, `standard` supports specifying a custom
 parser as well as an ESLint plugin to handle the changed syntax. Before using a JavaScript
 language variant, consider whether the added complexity is worth it.
 
-### Flow
+#### Flow
 
 To use Flow, you need to run `standard` with `babel-eslint` as the parser and
 `eslint-plugin-flowtype` as a plugin.
@@ -567,7 +573,7 @@ Or, add this to `package.json`:
 
 _Note: `plugin` and `plugins` are equivalent._
 
-### TypeScript
+#### TypeScript
 
 There are two officially supported methods of using standard with typescript files.
 
@@ -580,7 +586,7 @@ specific cli options and rules. The project uses `eslint-config-standard-with-ty
 
 An eslint configuration file with standard style javascript and typescript rules.
 
-## What about Mocha, Jest, Jasmine, QUnit, etc?
+### What about Mocha, Jest, Jasmine, QUnit, etc?
 
 To support mocha in test files, add this to the top of the test files:
 
@@ -604,7 +610,7 @@ module.
 
 _Note: `env` and `envs` are equivalent._
 
-## What about Web Workers and Service Workers?
+### What about Web Workers and Service Workers?
 
 Add this to the top of web worker files:
 
@@ -621,7 +627,7 @@ For Service workers, add this instead:
 /* eslint-env serviceworker */
 ```
 
-## What is the difference between warnings and errors?
+### What is the difference between warnings and errors?
 
 `standard` treats all rule violations as errors, which means that `standard`
 will exit with a non-zero (error) exit code.
@@ -644,7 +650,7 @@ features. We want using `standard` to be light and fun and so we're careful
 about making changes that may get in your way. As always, you can
 [disable a rule](#how-do-i-disable-a-rule) at any time, if necessary.
 
-## Can I check code inside of Markdown or HTML files?
+### Can I check code inside of Markdown or HTML files?
 
 To check code inside Markdown files, use [`standard-markdown`](https://www.npmjs.com/package/standard-markdown).
 
@@ -675,14 +681,14 @@ Then, to check JS that appears inside `<script>` tags, run:
 $ standard --plugin html '**/*.html'
 ```
 
-## Is there a Git `pre-commit` hook?
+### Is there a Git `pre-commit` hook?
 
-Yes! Hooks are great for ensuring that unstyled code never even makes it into your repo. 
+Yes! Hooks are great for ensuring that unstyled code never even makes it into your repo.
 Never give style feedback on a pull request again!
 
 You even have a choice...
 
-### Install your own hook
+#### Install your own hook
 
 ```bash
 #!/bin/bash
@@ -702,7 +708,7 @@ if [[ $? -ne 0 ]]; then
 fi
 ```
 
-### Use a `pre-commit` hook
+#### Use a `pre-commit` hook
 
 The [pre-commit](https://pre-commit.com/) library allows hooks to be declared within a `.pre-commit-config.yaml` configuration file in the repo, and therefore more easily maintained across a team.
 
@@ -730,7 +736,7 @@ Alternatively, for more advanced styling configurations, use `standard` within t
           # and whatever other plugins...
 ```
 
-## How do I make the output all colorful and pretty?
+### How do I make the output all colorful and pretty?
 
 The built-in output is simple and straightforward, but if you like shiny things,
 install [snazzy](https://www.npmjs.com/package/snazzy):
@@ -750,11 +756,11 @@ There's also [standard-tap](https://www.npmjs.com/package/standard-tap),
 [standard-reporter](https://www.npmjs.com/package/standard-reporter), and
 [standard-summary](https://www.npmjs.com/package/standard-summary).
 
-## Is there a Node.js API?
+### Is there a Node.js API?
 
 Yes!
 
-### `standard.lintText(text, [opts], callback)`
+#### `standard.lintText(text, [opts], callback)`
 
 Lint the provided source `text`. An `opts` object may be provided:
 
@@ -795,12 +801,12 @@ var results = {
 }
 ```
 
-### `results = standard.lintTextSync(text, [opts])`
+#### `results = standard.lintTextSync(text, [opts])`
 
 Synchronous version of `standard.lintText()`. If an error occurs, an exception is
 thrown. Otherwise, a `results` object is returned.
 
-### `standard.lintFiles(files, [opts], callback)`
+#### `standard.lintFiles(files, [opts], callback)`
 
 Lint the provided `files` globs. An `opts` object may be provided:
 
@@ -818,7 +824,7 @@ var opts = {
 
 The `callback` will be called with an `Error` and `results` object (same as above).
 
-## How do I contribute to StandardJS?
+### How do I contribute to StandardJS?
 
 Contributions are welcome! Check out the [issues](https://github.com/standard/standard/issues) or the [PRs](https://github.com/standard/standard/pulls), and make your own if you want something that you don't see there.
 

--- a/RULES.md
+++ b/RULES.md
@@ -23,7 +23,7 @@ your code.
 
 ## Rules
 
-* **Use 2 spaces** for indentation.
+- **Use 2 spaces** for indentation.
 
   eslint: [`indent`](http://eslint.org/docs/rules/indent)
 
@@ -33,7 +33,7 @@ your code.
   }
   ```
 
-* **Use single quotes for strings** except to avoid escaping.
+- **Use single quotes for strings** except to avoid escaping.
 
   eslint: [`quotes`](http://eslint.org/docs/rules/quotes)
 
@@ -46,7 +46,7 @@ your code.
   console.log(`hello ${name}`)  // ✓ ok
   ```
 
-* **No unused variables.**
+- **No unused variables.**
 
   eslint: [`no-unused-vars`](http://eslint.org/docs/rules/no-unused-vars)
 
@@ -56,7 +56,7 @@ your code.
   }
   ```
 
-* **Add a space after keywords.**
+- **Add a space after keywords.**
 
   eslint: [`keyword-spacing`](http://eslint.org/docs/rules/keyword-spacing)
 
@@ -65,7 +65,7 @@ your code.
   if(condition) { ... }    // ✗ avoid
   ```
 
-* **Add a space before a function declaration's parentheses.**
+- **Add a space before a function declaration's parentheses.**
 
   eslint: [`space-before-function-paren`](http://eslint.org/docs/rules/space-before-function-paren)
 
@@ -77,7 +77,7 @@ your code.
   run(function() { ... })       // ✗ avoid
   ```
 
-* **Always use** `===` instead of `==`.<br>
+- **Always use** `===` instead of `==`.<br>
   Exception: `obj == null` is allowed to check for `null || undefined`.
 
   eslint: [`eqeqeq`](http://eslint.org/docs/rules/eqeqeq)
@@ -92,7 +92,7 @@ your code.
   if (name != 'John')    // ✗ avoid
   ```
 
-* **Infix operators** must be spaced.
+- **Infix operators** must be spaced.
 
   eslint: [`space-infix-ops`](http://eslint.org/docs/rules/space-infix-ops)
 
@@ -108,7 +108,7 @@ your code.
   var message = 'hello, '+name+'!'
   ```
 
-* **Commas should have a space** after them.
+- **Commas should have a space** after them.
 
   eslint: [`comma-spacing`](http://eslint.org/docs/rules/comma-spacing)
 
@@ -124,7 +124,7 @@ your code.
   function greet (name,options) { ... }
   ```
 
-* **Keep else statements** on the same line as their curly braces.
+- **Keep else statements** on the same line as their curly braces.
 
   eslint: [`brace-style`](http://eslint.org/docs/rules/brace-style)
 
@@ -147,7 +147,7 @@ your code.
   }
   ```
 
-* **For multi-line if statements,** use curly braces.
+- **For multi-line if statements,** use curly braces.
 
   eslint: [`curly`](http://eslint.org/docs/rules/curly)
 
@@ -169,9 +169,10 @@ your code.
     console.log('done')
   ```
 
-* **Always handle the** `err` function parameter.
+- **Always handle the** `err` function parameter.
 
   eslint: [`handle-callback-err`](http://eslint.org/docs/rules/handle-callback-err)
+
   ```js
   // ✓ ok
   run(function (err) {
@@ -187,7 +188,7 @@ your code.
   })
   ```
 
-* **Declare browser globals** with a `/* global */` comment.<br>
+- **Declare browser globals** with a `/* global */` comment.<br>
   Exceptions are: `window`, `document`, and `navigator`.<br>
   Prevents accidental use of poorly-named browser globals like `open`, `length`,
   `event`, and `name`.
@@ -208,7 +209,7 @@ your code.
   window.alert('hi')   // ✓ ok
   ```
 
-* **Multiple blank lines not allowed.**
+- **Multiple blank lines not allowed.**
 
   eslint: [`no-multiple-empty-lines`](http://eslint.org/docs/rules/no-multiple-empty-lines)
 
@@ -228,7 +229,7 @@ your code.
   console.log(value)
   ```
 
-* **For the ternary operator** in a multi-line setting, place `?` and `:` on their own lines.
+- **For the ternary operator** in a multi-line setting, place `?` and `:` on their own lines.
 
   eslint: [`operator-linebreak`](http://eslint.org/docs/rules/operator-linebreak)
 
@@ -247,7 +248,7 @@ your code.
     'www.api.com'
   ```
 
-* **For var declarations,** write each declaration in its own statement.
+- **For var declarations,** write each declaration in its own statement.
 
   eslint: [`one-var`](http://eslint.org/docs/rules/one-var)
 
@@ -264,7 +265,7 @@ your code.
       verbose = true
   ```
 
-* **Wrap conditional assignments** with additional parentheses. This makes it clear that the expression is intentionally an assignment (`=`) rather than a typo for equality (`===`).
+- **Wrap conditional assignments** with additional parentheses. This makes it clear that the expression is intentionally an assignment (`=`) rather than a typo for equality (`===`).
 
   eslint: [`no-cond-assign`](http://eslint.org/docs/rules/no-cond-assign)
 
@@ -280,7 +281,7 @@ your code.
   }
   ```
 
-* **Add spaces inside single line blocks.**
+- **Add spaces inside single line blocks.**
 
   eslint: [`block-spacing`](http://eslint.org/docs/rules/block-spacing)
 
@@ -289,7 +290,7 @@ your code.
     function foo () { return true }  // ✓ ok
   ```
 
-* **Use camelcase when naming variables and functions.**
+- **Use camelcase when naming variables and functions.**
 
   eslint: [`camelcase`](http://eslint.org/docs/rules/camelcase)
 
@@ -301,7 +302,7 @@ your code.
     var myVar = 'hello'            // ✓ ok
   ```
 
-* **Trailing commas not allowed.**
+- **Trailing commas not allowed.**
 
   eslint: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle)
 
@@ -311,7 +312,7 @@ your code.
     }
   ```
 
-* **Commas must be placed at the end of the current line.**
+- **Commas must be placed at the end of the current line.**
 
   eslint: [`comma-style`](http://eslint.org/docs/rules/comma-style)
 
@@ -327,7 +328,7 @@ your code.
     }
   ```
 
-* **Dot should be on the same line as property.**
+- **Dot should be on the same line as property.**
 
   eslint: [`dot-location`](http://eslint.org/docs/rules/dot-location)
 
@@ -339,11 +340,11 @@ your code.
       .log('hello') // ✓ ok
   ```
 
-* **Files must end with a newline.**
+- **Files must end with a newline.**
 
   eslint: [`eol-last`](http://eslint.org/docs/rules/eol-last)
 
-* **No space between function identifiers and their invocations.**
+- **No space between function identifiers and their invocations.**
 
   eslint: [`func-call-spacing`](http://eslint.org/docs/rules/func-call-spacing)
 
@@ -352,7 +353,7 @@ your code.
   console.log('hello')  // ✓ ok
   ```
 
-* **Add space between colon and value in key value pairs.**
+- **Add space between colon and value in key value pairs.**
 
   eslint: [`key-spacing`](http://eslint.org/docs/rules/key-spacing)
 
@@ -363,7 +364,7 @@ your code.
   var obj = { 'key': 'value' }     // ✓ ok
   ```
 
-* **Constructor names must begin with a capital letter.**
+- **Constructor names must begin with a capital letter.**
 
   eslint: [`new-cap`](http://eslint.org/docs/rules/new-cap)
 
@@ -375,7 +376,7 @@ your code.
   var dog = new Animal()    // ✓ ok
   ```
 
-* **Constructor with no arguments must be invoked with parentheses.**
+- **Constructor with no arguments must be invoked with parentheses.**
 
   eslint: [`new-parens`](http://eslint.org/docs/rules/new-parens)
 
@@ -385,7 +386,7 @@ your code.
   var dog = new Animal()  // ✓ ok
   ```
 
-* **Objects must contain a getter when a setter is defined.**
+- **Objects must contain a getter when a setter is defined.**
 
   eslint: [`accessor-pairs`](http://eslint.org/docs/rules/accessor-pairs)
 
@@ -406,7 +407,7 @@ your code.
   }
   ```
 
-* **Constructors of derived classes must call `super`.**
+- **Constructors of derived classes must call `super`.**
 
   eslint: [`constructor-super`](http://eslint.org/docs/rules/constructor-super)
 
@@ -432,7 +433,7 @@ your code.
   }
   ```
 
-* **Use array literals instead of array constructors.**
+- **Use array literals instead of array constructors.**
 
   eslint: [`no-array-constructor`](http://eslint.org/docs/rules/no-array-constructor)
 
@@ -441,7 +442,7 @@ your code.
   var nums = [1, 2, 3]            // ✓ ok
   ```
 
-* **Avoid using `arguments.callee` and `arguments.caller`.**
+- **Avoid using `arguments.callee` and `arguments.caller`.**
 
   eslint: [`no-caller`](http://eslint.org/docs/rules/no-caller)
 
@@ -459,7 +460,7 @@ your code.
   }
   ```
 
-* **Avoid modifying variables of class declarations.**
+- **Avoid modifying variables of class declarations.**
 
   eslint: [`no-class-assign`](http://eslint.org/docs/rules/no-class-assign)
 
@@ -468,7 +469,7 @@ your code.
   Dog = 'Fido'    // ✗ avoid
   ```
 
-* **Avoid modifying variables declared using `const`.**
+- **Avoid modifying variables declared using `const`.**
 
   eslint: [`no-const-assign`](http://eslint.org/docs/rules/no-const-assign)
 
@@ -477,7 +478,7 @@ your code.
   score = 125       // ✗ avoid
   ```
 
-* **Avoid using constant expressions in conditions (except loops).**
+- **Avoid using constant expressions in conditions (except loops).**
 
   eslint: [`no-constant-condition`](http://eslint.org/docs/rules/no-constant-condition)
 
@@ -495,7 +496,7 @@ your code.
   }
   ```
 
-* **No control characters in regular expressions.**
+- **No control characters in regular expressions.**
 
   eslint: [`no-control-regex`](http://eslint.org/docs/rules/no-control-regex)
 
@@ -504,7 +505,7 @@ your code.
   var pattern = /\x20/    // ✓ ok
   ```
 
-* **No `debugger` statements.**
+- **No `debugger` statements.**
 
   eslint: [`no-debugger`](http://eslint.org/docs/rules/no-debugger)
 
@@ -515,7 +516,7 @@ your code.
   }
   ```
 
-* **No `delete` operator on variables.**
+- **No `delete` operator on variables.**
 
   eslint: [`no-delete-var`](http://eslint.org/docs/rules/no-delete-var)
 
@@ -524,7 +525,7 @@ your code.
   delete name     // ✗ avoid
   ```
 
-* **No duplicate arguments in function definitions.**
+- **No duplicate arguments in function definitions.**
 
   eslint: [`no-dupe-args`](http://eslint.org/docs/rules/no-dupe-args)
 
@@ -538,7 +539,7 @@ your code.
   }
   ```
 
-* **No duplicate name in class members.**
+- **No duplicate name in class members.**
 
   eslint: [`no-dupe-class-members`](http://eslint.org/docs/rules/no-dupe-class-members)
 
@@ -549,7 +550,7 @@ your code.
   }
   ```
 
-* **No duplicate keys in object literals.**
+- **No duplicate keys in object literals.**
 
   eslint: [`no-dupe-keys`](http://eslint.org/docs/rules/no-dupe-keys)
 
@@ -560,7 +561,7 @@ your code.
   }
   ```
 
-* **No duplicate `case` labels in `switch` statements.**
+- **No duplicate `case` labels in `switch` statements.**
 
   eslint: [`no-duplicate-case`](http://eslint.org/docs/rules/no-duplicate-case)
 
@@ -572,7 +573,7 @@ your code.
   }
   ```
 
-* **Use a single import statement per module.**
+- **Use a single import statement per module.**
 
   eslint: [`no-duplicate-imports`](http://eslint.org/docs/rules/no-duplicate-imports)
 
@@ -583,7 +584,7 @@ your code.
   import { myFunc1, myFunc2 } from 'module' // ✓ ok
   ```
 
-* **No empty character classes in regular expressions.**
+- **No empty character classes in regular expressions.**
 
   eslint: [`no-empty-character-class`](http://eslint.org/docs/rules/no-empty-character-class)
 
@@ -592,7 +593,7 @@ your code.
   const myRegex = /^abc[a-z]/   // ✓ ok
   ```
 
-* **No empty destructuring patterns.**
+- **No empty destructuring patterns.**
 
   eslint: [`no-empty-pattern`](http://eslint.org/docs/rules/no-empty-pattern)
 
@@ -601,7 +602,7 @@ your code.
   const { a: { b } } = foo      // ✓ ok
   ```
 
-* **No using `eval()`.**
+- **No using `eval()`.**
 
   eslint: [`no-eval`](http://eslint.org/docs/rules/no-eval)
 
@@ -610,7 +611,7 @@ your code.
   var result = user[propName]             // ✓ ok
   ```
 
-* **No reassigning exceptions in `catch` clauses.**
+- **No reassigning exceptions in `catch` clauses.**
 
   eslint: [`no-ex-assign`](http://eslint.org/docs/rules/no-ex-assign)
 
@@ -628,7 +629,7 @@ your code.
   }
   ```
 
-* **No extending native objects.**
+- **No extending native objects.**
 
   eslint: [`no-extend-native`](http://eslint.org/docs/rules/no-extend-native)
 
@@ -636,7 +637,7 @@ your code.
   Object.prototype.age = 21     // ✗ avoid
   ```
 
-* **Avoid unnecessary function binding.**
+- **Avoid unnecessary function binding.**
 
   eslint: [`no-extra-bind`](http://eslint.org/docs/rules/no-extra-bind)
 
@@ -650,7 +651,7 @@ your code.
   }.bind(user)    // ✓ ok
   ```
 
-* **Avoid unnecessary boolean casts.**
+- **Avoid unnecessary boolean casts.**
 
   eslint: [`no-extra-boolean-cast`](http://eslint.org/docs/rules/no-extra-boolean-cast)
 
@@ -666,7 +667,7 @@ your code.
   }
   ```
 
-* **No unnecessary parentheses around function expressions.**
+- **No unnecessary parentheses around function expressions.**
 
   eslint: [`no-extra-parens`](http://eslint.org/docs/rules/no-extra-parens)
 
@@ -675,7 +676,7 @@ your code.
   const myFunc = function () { }     // ✓ ok
   ```
 
-* **Use `break` to prevent fallthrough in `switch` cases.**
+- **Use `break` to prevent fallthrough in `switch` cases.**
 
   eslint: [`no-fallthrough`](http://eslint.org/docs/rules/no-fallthrough)
 
@@ -704,7 +705,7 @@ your code.
   }
   ```
 
-* **No floating decimals.**
+- **No floating decimals.**
 
   eslint: [`no-floating-decimal`](http://eslint.org/docs/rules/no-floating-decimal)
 
@@ -713,7 +714,7 @@ your code.
   const discount = 0.5     // ✓ ok
   ```
 
-* **Avoid reassigning function declarations.**
+- **Avoid reassigning function declarations.**
 
   eslint: [`no-func-assign`](http://eslint.org/docs/rules/no-func-assign)
 
@@ -722,7 +723,7 @@ your code.
   myFunc = myOtherFunc    // ✗ avoid
   ```
 
-* **No reassigning read-only global variables.**
+- **No reassigning read-only global variables.**
 
   eslint: [`no-global-assign`](http://eslint.org/docs/rules/no-global-assign)
 
@@ -730,7 +731,7 @@ your code.
   window = {}     // ✗ avoid
   ```
 
-* **No implied `eval()`.**
+- **No implied `eval()`.**
 
   eslint: [`no-implied-eval`](http://eslint.org/docs/rules/no-implied-eval)
 
@@ -739,7 +740,7 @@ your code.
   setTimeout(function () { alert('Hello world') })     // ✓ ok
   ```
 
-* **No function declarations in nested blocks.**
+- **No function declarations in nested blocks.**
 
   eslint: [`no-inner-declarations`](http://eslint.org/docs/rules/no-inner-declarations)
 
@@ -749,7 +750,7 @@ your code.
   }
   ```
 
-* **No invalid regular expression strings in  `RegExp` constructors.**
+- **No invalid regular expression strings in  `RegExp` constructors.**
 
   eslint: [`no-invalid-regexp`](http://eslint.org/docs/rules/no-invalid-regexp)
 
@@ -758,7 +759,7 @@ your code.
   RegExp('[a-z]')   // ✓ ok
   ```
 
-* **No irregular whitespace.**
+- **No irregular whitespace.**
 
   eslint: [`no-irregular-whitespace`](http://eslint.org/docs/rules/no-irregular-whitespace)
 
@@ -766,7 +767,7 @@ your code.
   function myFunc () /*<NBSP>*/{}   // ✗ avoid
   ```
 
-* **No using `__iterator__`.**
+- **No using `__iterator__`.**
 
   eslint: [`no-iterator`](http://eslint.org/docs/rules/no-iterator)
 
@@ -774,7 +775,7 @@ your code.
   Foo.prototype.__iterator__ = function () {}   // ✗ avoid
   ```
 
-* **No labels that share a name with an in scope variable.**
+- **No labels that share a name with an in scope variable.**
 
   eslint: [`no-label-var`](http://eslint.org/docs/rules/no-label-var)
 
@@ -789,7 +790,7 @@ your code.
   }
   ```
 
-* **No label statements.**
+- **No label statements.**
 
   eslint: [`no-labels`](http://eslint.org/docs/rules/no-labels)
 
@@ -800,7 +801,7 @@ your code.
     }
   ```
 
-* **No unnecessary nested blocks.**
+- **No unnecessary nested blocks.**
 
   eslint: [`no-lone-blocks`](http://eslint.org/docs/rules/no-lone-blocks)
 
@@ -816,11 +817,11 @@ your code.
   }
   ```
 
-* **Avoid mixing spaces and tabs for indentation.**
+- **Avoid mixing spaces and tabs for indentation.**
 
   eslint: [`no-mixed-spaces-and-tabs`](http://eslint.org/docs/rules/no-mixed-spaces-and-tabs)
 
-* **Do not use multiple spaces except for indentation.**
+- **Do not use multiple spaces except for indentation.**
 
   eslint: [`no-multi-spaces`](http://eslint.org/docs/rules/no-multi-spaces)
 
@@ -829,7 +830,7 @@ your code.
   const id = 1234       // ✓ ok
   ```
 
-* **No multiline strings.**
+- **No multiline strings.**
 
   eslint: [`no-multi-str`](http://eslint.org/docs/rules/no-multi-str)
 
@@ -838,7 +839,7 @@ your code.
                    world'     // ✗ avoid
   ```
 
-* **No `new` without assigning object to a variable.**
+- **No `new` without assigning object to a variable.**
 
   eslint: [`no-new`](http://eslint.org/docs/rules/no-new)
 
@@ -847,7 +848,7 @@ your code.
   const character = new Character()   // ✓ ok
   ```
 
-* **No using the `Function` constructor.**
+- **No using the `Function` constructor.**
 
   eslint: [`no-new-func`](http://eslint.org/docs/rules/no-new-func)
 
@@ -855,7 +856,7 @@ your code.
   var sum = new Function('a', 'b', 'return a + b')    // ✗ avoid
   ```
 
-* **No using the `Object` constructor.**
+- **No using the `Object` constructor.**
 
   eslint: [`no-new-object`](http://eslint.org/docs/rules/no-new-object)
 
@@ -863,7 +864,7 @@ your code.
   let config = new Object()   // ✗ avoid
   ```
 
-* **No using `new require`.**
+- **No using `new require`.**
 
   eslint: [`no-new-require`](http://eslint.org/docs/rules/no-new-require)
 
@@ -871,7 +872,7 @@ your code.
   const myModule = new require('my-module')    // ✗ avoid
   ```
 
-* **No using the `Symbol` constructor.**
+- **No using the `Symbol` constructor.**
 
   eslint: [`no-new-symbol`](http://eslint.org/docs/rules/no-new-symbol)
 
@@ -879,7 +880,7 @@ your code.
   const foo = new Symbol('foo')   // ✗ avoid
   ```
 
-* **No using primitive wrapper instances.**
+- **No using primitive wrapper instances.**
 
   eslint: [`no-new-wrappers`](http://eslint.org/docs/rules/no-new-wrappers)
 
@@ -887,7 +888,7 @@ your code.
   const message = new String('hello')   // ✗ avoid
   ```
 
-* **No calling global object properties as functions.**
+- **No calling global object properties as functions.**
 
   eslint: [`no-obj-calls`](http://eslint.org/docs/rules/no-obj-calls)
 
@@ -895,7 +896,7 @@ your code.
   const math = Math()   // ✗ avoid
   ```
 
-* **No octal literals.**
+- **No octal literals.**
 
   eslint: [`no-octal`](http://eslint.org/docs/rules/no-octal)
 
@@ -905,7 +906,7 @@ your code.
   const octalString = '042' // ✓ ok
   ```
 
-* **No octal escape sequences in string literals.**
+- **No octal escape sequences in string literals.**
 
   eslint: [`no-octal-escape`](http://eslint.org/docs/rules/no-octal-escape)
 
@@ -913,7 +914,7 @@ your code.
   const copyright = 'Copyright \251'  // ✗ avoid
   ```
 
-* **Avoid string concatenation when using `__dirname` and `__filename`.**
+- **Avoid string concatenation when using `__dirname` and `__filename`.**
 
   eslint: [`no-path-concat`](http://eslint.org/docs/rules/no-path-concat)
 
@@ -922,7 +923,7 @@ your code.
   const pathToFile = path.join(__dirname, 'app.js')   // ✓ ok
   ```
 
-* **Avoid using `__proto__`.** Use `getPrototypeOf` instead.
+- **Avoid using `__proto__`.** Use `getPrototypeOf` instead.
 
   eslint: [`no-proto`](http://eslint.org/docs/rules/no-proto)
 
@@ -931,7 +932,7 @@ your code.
   const foo = Object.getPrototypeOf(obj)  // ✓ ok
   ```
 
-* **No redeclaring variables.**
+- **No redeclaring variables.**
 
   eslint: [`no-redeclare`](http://eslint.org/docs/rules/no-redeclare)
 
@@ -943,7 +944,7 @@ your code.
   name = 'Jane'         // ✓ ok
   ```
 
-* **Avoid multiple spaces in regular expression literals.**
+- **Avoid multiple spaces in regular expression literals.**
 
   eslint: [`no-regex-spaces`](http://eslint.org/docs/rules/no-regex-spaces)
 
@@ -954,7 +955,7 @@ your code.
   const regexp = /test value/     // ✓ ok
   ```
 
-* **Assignments in return statements must be surrounded by parentheses.**
+- **Assignments in return statements must be surrounded by parentheses.**
 
   eslint: [`no-return-assign`](http://eslint.org/docs/rules/no-return-assign)
 
@@ -968,7 +969,7 @@ your code.
   }
   ```
 
-* **Avoid assigning a variable to itself**
+- **Avoid assigning a variable to itself**
 
   eslint: [`no-self-assign`](http://eslint.org/docs/rules/no-self-assign)
 
@@ -976,7 +977,7 @@ your code.
   name = name   // ✗ avoid
   ```
 
-* **Avoid comparing a variable to itself.**
+- **Avoid comparing a variable to itself.**
 
   eslint: [`no-self-compare`](http://eslint.org/docs/rules/no-self-compare)
 
@@ -984,7 +985,7 @@ your code.
   if (score === score) {}   // ✗ avoid
   ```
 
-* **Avoid using the comma operator.**
+- **Avoid using the comma operator.**
 
   eslint: [`no-sequences`](http://eslint.org/docs/rules/no-sequences)
 
@@ -992,7 +993,7 @@ your code.
   if (doSomething(), !!test) {}   // ✗ avoid
   ```
 
-* **Restricted names should not be shadowed.**
+- **Restricted names should not be shadowed.**
 
   eslint: [`no-shadow-restricted-names`](http://eslint.org/docs/rules/no-shadow-restricted-names)
 
@@ -1000,7 +1001,7 @@ your code.
   let undefined = 'value'     // ✗ avoid
   ```
 
-* **Sparse arrays are not allowed.**
+- **Sparse arrays are not allowed.**
 
   eslint: [`no-sparse-arrays`](http://eslint.org/docs/rules/no-sparse-arrays)
 
@@ -1008,11 +1009,11 @@ your code.
   let fruits = ['apple',, 'orange']       // ✗ avoid
   ```
 
-* **Tabs should not be used**
+- **Tabs should not be used**
 
   eslint: [`no-tabs`](http://eslint.org/docs/rules/no-tabs)
 
-* **Regular strings must not contain template literal placeholders.**
+- **Regular strings must not contain template literal placeholders.**
 
   eslint: [`no-template-curly-in-string`](http://eslint.org/docs/rules/no-template-curly-in-string)
 
@@ -1021,7 +1022,7 @@ your code.
   const message = `Hello ${name}`   // ✓ ok
   ```
 
-* **`super()` must be called before using `this`.**
+- **`super()` must be called before using `this`.**
 
   eslint: [`no-this-before-super`](http://eslint.org/docs/rules/no-this-before-super)
 
@@ -1034,7 +1035,7 @@ your code.
   }
   ```
 
-* **Only `throw` an `Error` object.**
+- **Only `throw` an `Error` object.**
 
   eslint: [`no-throw-literal`](http://eslint.org/docs/rules/no-throw-literal)
 
@@ -1043,11 +1044,11 @@ your code.
   throw new Error('error')    // ✓ ok
   ```
 
-* **Whitespace not allowed at end of line.**
+- **Whitespace not allowed at end of line.**
 
   eslint: [`no-trailing-spaces`](http://eslint.org/docs/rules/no-trailing-spaces)
 
-* **Initializing to `undefined` is not allowed.**
+- **Initializing to `undefined` is not allowed.**
 
   eslint: [`no-undef-init`](http://eslint.org/docs/rules/no-undef-init)
 
@@ -1058,7 +1059,7 @@ your code.
   name = 'value'          // ✓ ok
   ```
 
-* **No unmodified conditions of loops.**
+- **No unmodified conditions of loops.**
 
   eslint: [`no-unmodified-loop-condition`](http://eslint.org/docs/rules/no-unmodified-loop-condition)
 
@@ -1067,7 +1068,7 @@ your code.
   for (let i = 0; i < items.length; i++) {...}    // ✓ ok
   ```
 
-* **No ternary operators when simpler alternatives exist.**
+- **No ternary operators when simpler alternatives exist.**
 
   eslint: [`no-unneeded-ternary`](http://eslint.org/docs/rules/no-unneeded-ternary)
 
@@ -1076,7 +1077,7 @@ your code.
   let score = val || 0          // ✓ ok
   ```
 
-* **No unreachable code after `return`, `throw`, `continue`, and `break` statements.**
+- **No unreachable code after `return`, `throw`, `continue`, and `break` statements.**
 
   eslint: [`no-unreachable`](http://eslint.org/docs/rules/no-unreachable)
 
@@ -1087,7 +1088,7 @@ your code.
   }
   ```
 
-* **No flow control statements in `finally` blocks.**
+- **No flow control statements in `finally` blocks.**
 
   eslint: [`no-unsafe-finally`](http://eslint.org/docs/rules/no-unsafe-finally)
 
@@ -1101,7 +1102,7 @@ your code.
   }
   ```
 
-* **The left operand of relational operators must not be negated.**
+- **The left operand of relational operators must not be negated.**
 
   eslint: [`no-unsafe-negation`](http://eslint.org/docs/rules/no-unsafe-negation)
 
@@ -1110,7 +1111,7 @@ your code.
   if (!(key in obj)) {}     // ✓ ok
   ```
 
-* **Avoid unnecessary use of `.call()` and `.apply()`.**
+- **Avoid unnecessary use of `.call()` and `.apply()`.**
 
   eslint: [`no-useless-call`](http://eslint.org/docs/rules/no-useless-call)
 
@@ -1118,7 +1119,7 @@ your code.
   sum.call(null, 1, 2, 3)   // ✗ avoid
   ```
 
-* **Avoid using unnecessary computed property keys on objects.**
+- **Avoid using unnecessary computed property keys on objects.**
 
   eslint: [`no-useless-computed-key`](http://eslint.org/docs/rules/no-useless-computed-key)
 
@@ -1127,7 +1128,7 @@ your code.
   const user = { name: 'John Doe' }       // ✓ ok
   ```
 
-* **No unnecessary constructor.**
+- **No unnecessary constructor.**
 
   eslint: [`no-useless-constructor`](http://eslint.org/docs/rules/no-useless-constructor)
 
@@ -1138,7 +1139,7 @@ your code.
   }
   ```
 
-* **No unnecessary use of escape.**
+- **No unnecessary use of escape.**
 
   eslint: [`no-useless-escape`](http://eslint.org/docs/rules/no-useless-escape)
 
@@ -1146,7 +1147,7 @@ your code.
   let message = 'Hell\o'  // ✗ avoid
   ```
 
-* **Renaming import, export, and destructured assignments to the same name is not allowed.**
+- **Renaming import, export, and destructured assignments to the same name is not allowed.**
 
   eslint: [`no-useless-rename`](http://eslint.org/docs/rules/no-useless-rename)
 
@@ -1155,7 +1156,7 @@ your code.
   import { config } from './config'               // ✓ ok
   ```
 
-* **No whitespace before properties.**
+- **No whitespace before properties.**
 
   eslint: [`no-whitespace-before-property`](http://eslint.org/docs/rules/no-whitespace-before-property)
 
@@ -1164,7 +1165,7 @@ your code.
   user.name       // ✓ ok
   ```
 
-* **No using `with` statements.**
+- **No using `with` statements.**
 
   eslint: [`no-with`](http://eslint.org/docs/rules/no-with)
 
@@ -1172,7 +1173,7 @@ your code.
   with (val) {...}    // ✗ avoid
   ```
 
-* **Maintain consistency of newlines between object properties.**
+- **Maintain consistency of newlines between object properties.**
 
   eslint: [`object-property-newline`](http://eslint.org/docs/rules/object-property-newline)
 
@@ -1191,7 +1192,7 @@ your code.
   }                                                                 // ✓ ok
   ```
 
-* **No padding within blocks.**
+- **No padding within blocks.**
 
   eslint: [`padded-blocks`](http://eslint.org/docs/rules/padded-blocks)
 
@@ -1207,7 +1208,7 @@ your code.
   }
   ```
 
-* **No whitespace between spread operators and their expressions.**
+- **No whitespace between spread operators and their expressions.**
 
   eslint: [`rest-spread-spacing`](http://eslint.org/docs/rules/rest-spread-spacing)
 
@@ -1216,7 +1217,7 @@ your code.
   fn(...args)     // ✓ ok
   ```
 
-* **Semicolons must have a space after and no space before.**
+- **Semicolons must have a space after and no space before.**
 
   eslint: [`semi-spacing`](http://eslint.org/docs/rules/semi-spacing)
 
@@ -1225,7 +1226,7 @@ your code.
   for (let i = 0; i < items.length; i++) {...}    // ✓ ok
   ```
 
-* **Must have a space before blocks.**
+- **Must have a space before blocks.**
 
   eslint: [`space-before-blocks`](http://eslint.org/docs/rules/space-before-blocks)
 
@@ -1234,7 +1235,7 @@ your code.
   if (admin) {...}    // ✓ ok
   ```
 
-* **No spaces inside parentheses.**
+- **No spaces inside parentheses.**
 
   eslint: [`space-in-parens`](http://eslint.org/docs/rules/space-in-parens)
 
@@ -1243,7 +1244,7 @@ your code.
   getName(name)       // ✓ ok
   ```
 
-* **Unary operators must have a space after.**
+- **Unary operators must have a space after.**
 
   eslint: [`space-unary-ops`](http://eslint.org/docs/rules/space-unary-ops)
 
@@ -1252,7 +1253,7 @@ your code.
   typeof !admin        // ✓ ok
   ```
 
-* **Use spaces inside comments.**
+- **Use spaces inside comments.**
 
   eslint: [`spaced-comment`](http://eslint.org/docs/rules/spaced-comment)
 
@@ -1264,7 +1265,7 @@ your code.
   /* comment */       // ✓ ok
   ```
 
-* **No spacing in template strings.**
+- **No spacing in template strings.**
 
   eslint: [`template-curly-spacing`](http://eslint.org/docs/rules/template-curly-spacing)
 
@@ -1273,7 +1274,7 @@ your code.
   const message = `Hello, ${name}`      // ✓ ok
   ```
 
-* **Use `isNaN()` when checking for `NaN`.**
+- **Use `isNaN()` when checking for `NaN`.**
 
   eslint: [`use-isnan`](http://eslint.org/docs/rules/use-isnan)
 
@@ -1282,7 +1283,7 @@ your code.
   if (isNaN(price)) { }       // ✓ ok
   ```
 
-* **`typeof` must be compared to a valid string.**
+- **`typeof` must be compared to a valid string.**
 
   eslint: [`valid-typeof`](http://eslint.org/docs/rules/valid-typeof)
 
@@ -1291,7 +1292,7 @@ your code.
   typeof name === 'undefined'     // ✓ ok
   ```
 
-* **Immediately Invoked Function Expressions (IIFEs) must be wrapped.**
+- **Immediately Invoked Function Expressions (IIFEs) must be wrapped.**
 
   eslint: [`wrap-iife`](http://eslint.org/docs/rules/wrap-iife)
 
@@ -1302,7 +1303,7 @@ your code.
   const getName = (function () { })()   // ✓ ok
   ```
 
-* **The `*` in `yield*`expressions must have a space before and after.**
+- **The `*` in `yield*`expressions must have a space before and after.**
 
   eslint: [`yield-star-spacing`](http://eslint.org/docs/rules/yield-star-spacing)
 
@@ -1311,7 +1312,7 @@ your code.
   yield * increment()   // ✓ ok
   ```
 
-* **Avoid Yoda conditions.**
+- **Avoid Yoda conditions.**
 
   eslint: [`yoda`](http://eslint.org/docs/rules/yoda)
 
@@ -1322,7 +1323,7 @@ your code.
 
 ## Semicolons
 
-* No semicolons. (see: [1](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding), [2](http://inimino.org/%7Einimino/blog/javascript_semicolons), [3](https://www.youtube.com/watch?v=gsfbh17Ax9I))
+- No semicolons. (see: [1](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding), [2](http://inimino.org/%7Einimino/blog/javascript_semicolons), [3](https://www.youtube.com/watch?v=gsfbh17Ax9I))
 
   eslint: [`semi`](http://eslint.org/docs/rules/semi)
 
@@ -1331,7 +1332,7 @@ your code.
   window.alert('hi');  // ✗ avoid
   ```
 
-* Never start a line with `(`, `[`, `` ` ``, or a handful of other unlikely possibilities.
+- Never start a line with `(`, `[`, `` ` ``, or a handful of other unlikely possibilities.
 
   This is the only gotcha with omitting semicolons, and `standard` protects you from this potential issue.
 
@@ -1385,7 +1386,6 @@ your code.
   nums.forEach(bar)
   ```
 
-
 ## Helpful reading
 
 - [An Open Letter to JavaScript Leaders Regarding Semicolons][1]
@@ -1399,20 +1399,21 @@ All popular code minifiers in use today use AST-based minification, so they can
 handle semicolon-less JavaScript with no issues (since semicolons are not required
 in JavaScript).
 
-##### Excerpt from *["An Open Letter to JavaScript Leaders Regarding Semicolons"][1]*:
+##### Excerpt from _["An Open Letter to JavaScript Leaders Regarding Semicolons"][1]_:
 
 > [Relying on automatic semicolon insertion] is quite safe, and perfectly valid JS that every browser understands. Closure compiler, yuicompressor, packer, and jsmin all can properly minify it. There is no performance impact anywhere.
 >
 > I am sorry that, instead of educating you, the leaders in this language community have given you lies and fear.  That was shameful. I recommend learning how statements in JS are actually terminated (and in which cases they are not terminated), so that you can write code that you find beautiful.
 >
 > In general, `\n` ends a statement unless:
->   1. The statement has an unclosed paren, array literal, or object literal or ends in some
->      other way that is not a valid way to end a statement. (For instance, ending with `.`
->      or `,`.)
->   2. The line is `--` or `++` (in which case it will decrement/increment the next token.)
->   3. It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
->   4. The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other
->      binary operator that can only be found between two tokens in a single expression.
+>
+> 1. The statement has an unclosed paren, array literal, or object literal or ends in some
+>    other way that is not a valid way to end a statement. (For instance, ending with `.`
+>    or `,`.)
+> 2. The line is `--` or `++` (in which case it will decrement/increment the next token.)
+> 3. It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
+> 4. The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other
+>    binary operator that can only be found between two tokens in a single expression.
 >
 > The first is pretty obvious. Even JSLint is ok with `\n` chars in JSON and parenthesized constructs, and with `var` statements that span multiple lines ending in `,`.
 >
@@ -1422,7 +1423,7 @@ in JavaScript).
 >
 > `;` is a valid JavaScript statement, so `if(x);` is equivalent to `if(x){}` or, “If x, do nothing.” This is more commonly applied to loops where the loop check also is the update function. Unusual, but not unheard of.
 >
-> The fourth is generally the fud-inducing “oh noes, you need semicolons!” case. But, as it turns out, it’s quite easy to *prefix* those lines with semicolons if you don’t mean them to be continuations of the previous line. For example, instead of this:
+> The fourth is generally the fud-inducing “oh noes, you need semicolons!” case. But, as it turns out, it’s quite easy to _prefix_ those lines with semicolons if you don’t mean them to be continuations of the previous line. For example, instead of this:
 >
 > ```js
 > foo();
@@ -1439,5 +1440,7 @@ in JavaScript).
 > The advantage is that the prefixes are easier to notice, once you are accustomed to never seeing lines starting with `(` or `[` without semis.
 
 [1]: http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding
+
 [2]: http://inimino.org/~inimino/blog/javascript_semicolons
+
 [3]: https://www.youtube.com/watch?v=gsfbh17Ax9I

--- a/RULES.md
+++ b/RULES.md
@@ -212,6 +212,8 @@ your code.
 
   eslint: [`no-multiple-empty-lines`](http://eslint.org/docs/rules/no-multiple-empty-lines)
 
+  Note: `␊` represents a line feed.
+
   ```js
   // ✓ ok
   var value = 'hello world'
@@ -221,8 +223,8 @@ your code.
   ```js
   // ✗ avoid
   var value = 'hello world'
-
-
+  ␊
+  ␊
   console.log(value)
   ```
 
@@ -415,7 +417,7 @@ your code.
       this.legs = 4
     }
   }
-  
+
   class Dog extends Animal {
     constructor () {      // ✗ avoid
       this.legs = 4

--- a/RULES.md
+++ b/RULES.md
@@ -1401,7 +1401,7 @@ in JavaScript).
 
 ##### Excerpt from _["An Open Letter to JavaScript Leaders Regarding Semicolons"][1]_:
 
-> [Relying on automatic semicolon insertion] is quite safe, and perfectly valid JS that every browser understands. Closure compiler, yuicompressor, packer, and jsmin all can properly minify it. There is no performance impact anywhere.
+> \[Relying on automatic semicolon insertion] is quite safe, and perfectly valid JS that every browser understands. Closure compiler, yuicompressor, packer, and jsmin all can properly minify it. There is no performance impact anywhere.
 >
 > I am sorry that, instead of educating you, the leaders in this language community have given you lies and fear.  That was shameful. I recommend learning how statements in JS are actually terminated (and in which cases they are not terminated), so that you can write code that you find beautiful.
 >


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update

**What changes did you make?**

I separated this PR into multiple commits for review purposes. It can be merged as one.

The first commits are manual changes to `CHANGELOG.md`: ee72ed6, f7f9154, 50cf0fc, f2f87fb. These commits make it so you can run `hallmark lint CHANGELOG.md` without lint errors. Which also means you can run `hallmark bump minor` (similar to `npm version minor`) to add a new changelog entry prepopulated with git commits.

The later commits (d9ceefc, 88af2e9, 2023291, b453273, 5af9072) are optional because they touch other markdown files and may affect the website. Specifically, they change the depth of headings and collapse the Table of Contents. On the plus side, the ToC is automatically updated when you run `hallmark fix`. If you like these commits then I can make the same changes to the translations in `docs/*.md`. Let me know. Depending on that, I will also add `hallmark` to the npm test script, either linting all files or only `CHANGELOG.md` to start.

**Which issue (if any) does this pull request address?**

Closes #1606.

**Is there anything you'd like reviewers to focus on?**

Is the changelog structure satisfying or should we consider alternative solutions?