### PR TITLE
chore: improve URL behind test status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <p align="center">
   <a href="https://discord.gg/ZegqCBr"><img src="https://img.shields.io/discord/612704110008991783" alt="discord"></a>
-  <a href="https://github.com/standard/standard/workflows/Test/badge.svg"><img src="https://github.com/standard/standard/workflows/Test/badge.svg" alt="status badge Node tests"></a>
-  <a href="https://github.com/standard/standard/workflows/Old%20test/badge.svg"><img src="https://github.com/standard/standard/workflows/Old%20test/badge.svg" alt="status badge old Node test"></a>
+  <a href="https://github.com/standard/standard/actions?query=workflow%3ATest"><img src="https://github.com/standard/standard/workflows/Test/badge.svg" alt="status badge Node tests"></a>
+  <a href="https://github.com/standard/standard/actions?query=workflow%3A%22Old+test%22"><img src="https://github.com/standard/standard/workflows/Old%20test/badge.svg" alt="status badge old Node test"></a>
   <a href="https://www.npmjs.com/package/standard"><img src="https://img.shields.io/npm/v/standard.svg" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/eslint-config-standard"><img src="https://img.shields.io/npm/dm/eslint-config-standard.svg" alt="npm downloads"></a>
   <a href="https://standardjs.com"><img src="https://img.shields.io/badge/code_style-standard-brightgreen.svg" alt="Standard - JavaScript Style Guide"></a>


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain: improve URL behind test status badges

**What changes did you make? (Give an overview)**

Change the URL behind the test status badges to point to the GitHub Action search screen.
The query string is pre-filled so that you land on the action for the badge you clicked on.

**Which issue (if any) does this pull request address?**

I think it looks a bit weird if you click on the badge, and then see the badge SVG instead of an overview of the latest Actions for that badge.

**Is there anything you'd like reviewers to focus on?**

Double check if you're happy with the new URL. 😉 

Alternative option: point to the general GitHub Actions landing page: https://github.com/standard/standard/actions for both badges.