### PR TITLE
ci: add automated release on npm : `npm-publish`

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,37 @@
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: 'Publish package to npm'
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v2'
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: 'Cache Node dependencies'
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: 'Install dependencies'
+        run: 'npm install'
+
+      - name: 'Run tests'
+        run: 'npm test'
+
+      - name: 'Publish to npm registry'
+        run: 'npm publish --access public'
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: Add automated release process on `npm`

**What changes did you make? (Give an overview)**

- Create a GitHub Action to automatically release the package on npm when someone create a new release on GitHub (see `.github/workflows/npm-publish.yml)`
You will need to set a new secret `NPM_TOKEN` on the repo so it could works as it is [explained there](https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-nodejs-packages).

Also once this has been merged, I'll open smiliar PRs to `ts-standard`, `standard-engine`,  `eslint-config-standard` and `eslint-config-standard-with-typescript`.

Why is this important ? It's much better to have automated deployment, also sometime, you publish to npm but you forgot to create the release on GitHub, so now the releases would be synchronized and it's automated.