### PR TITLE
ci: set fail-fast to false, so that all tests run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+      fail-fast: false
 
     steps:
       - name: Checkout project


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain: improve CI config

**What changes did you make? (Give an overview)**

- Allow all matrix jobs to finish by setting `fail-fast` to `false`

**Which issue (if any) does this pull request address?**

By default GitHub cancels all in-progress jobs if any matrix job fails.
I'm overriding the default by setting the `fail-fast` property to `false`.
This way you can pinpoint which version(s) of Node are causing problems.

I noticed a Dependabot PR was not finishing the full test-suite (#1633), because the Node 14.x build was failing.
I think it can be helpful to know where the problems are, maybe Node 10.x and 12.x are good, but only Node 14 is failing, that's good information to have, I think.

[GitHub docs for fail-fast property](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)

**Is there anything you'd like reviewers to focus on?**

Check if I'm putting this property in the correct place.