### PR TITLE
chore: remove typescript files from .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,5 @@
   language: node
   files: "\\.(\
     js|jsx\
-    |ts|tsx\
     |mjs|cjs\
     )$"


### PR DESCRIPTION
Since typescript syntax is not supported by the linter, by default IMO we should not lint these files.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Remove `.ts`/`.tsx` files from the pre-commit lint hook

**Which issue (if any) does this pull request address?**

In my mixed JavaScript/TypeScript project that uses pre-commit, I'm getting a syntax error (`Parsing error: Unexpected token :`) when `standard` tries to lint a TypeScript file

**Is there anything you'd like reviewers to focus on?**
