### PR TITLE
feat: usage of ESM imports instead of CommonJS

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.20.0, 14.13.1, 16.0.0]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-internal.yml
+++ b/.github/workflows/test-internal.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.20.0, 14.13.1, 16.0.0]
       fail-fast: false
 
     steps:

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
-/* eslint-disable no-var */
+/* eslint-disable no-var, no-eval */
 
 var match = process.version.match(/v(\d+)\.(\d+)/)
 var major = parseInt(match[1], 10)
 var minor = parseInt(match[2], 10)
 
 if (major >= 12 || (major === 12 && minor >= 20)) {
-  import('standard-engine').then(function (standardEngine) {
-    import('../options.js').then(function (options) {
+  eval('import("standard-engine")').then(function (standardEngine) {
+    eval('import("../options.js")').then(function (options) {
       standardEngine.cli(options.default)
     })
   })

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -5,8 +5,12 @@ var match = process.version.match(/v(\d+)\.(\d+)/)
 var major = parseInt(match[1], 10)
 var minor = parseInt(match[2], 10)
 
-if (major >= 11 || (major === 10 && minor >= 12)) {
-  require('standard-engine').cli(require('../options'))
+if (major >= 12 || (major === 12 && minor >= 20)) {
+  import('standard-engine').then(mod => {
+    import('../options.js').then(({ default: options }) => {
+      mod.cli(options)
+    })
+  })
 } else {
-  console.error('standard: Node 10.12.0 or greater is required. `standard` did not run.')
+  console.error('standard: Node 12.20.0 or greater is required. `standard` did not run.')
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -6,9 +6,9 @@ var major = parseInt(match[1], 10)
 var minor = parseInt(match[2], 10)
 
 if (major >= 12 || (major === 12 && minor >= 20)) {
-  import('standard-engine').then(mod => {
-    import('../options.js').then(({ default: options }) => {
-      mod.cli(options)
+  import('standard-engine').then(function (standardEngine) {
+    import('../options.js').then(function (options) {
+      standardEngine.cli(options.default)
     })
   })
 } else {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 /*! standard. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
 import engine from 'standard-engine'
-import opts from './options.js'
+import options from './options.js'
 
-const Linter = engine.linter
-
-export default new Linter(opts)
+export default new engine.linter(options)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 /*! standard. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
-const Linter = require('standard-engine').linter
-const opts = require('./options')
+import engine from 'standard-engine'
+import opts from './options.js'
 
-module.exports = new Linter(opts)
+const Linter = engine.linter
+
+export default new Linter(opts)

--- a/index.js
+++ b/index.js
@@ -2,4 +2,6 @@
 import engine from 'standard-engine'
 import options from './options.js'
 
-export default new engine.linter(options)
+const Linter = engine.linter
+
+export default new Linter(options)

--- a/options.js
+++ b/options.js
@@ -1,8 +1,9 @@
 import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import eslint from 'eslint'
 
 // eslintConfig.configFile have problem reading URLs and file:///
-const configFile = new URL('./eslintrc.json', import.meta.url).toString().slice(7)
+const configFile = fileURLToPath(new URL('./eslintrc.json', import.meta.url))
 const pkgURL = new URL('./package.json', import.meta.url)
 const pkgJSON = readFileSync(pkgURL, { encoding: 'utf-8' })
 const pkg = JSON.parse(pkgJSON)

--- a/options.js
+++ b/options.js
@@ -1,15 +1,21 @@
-const eslint = require('eslint')
-const path = require('path')
-const pkg = require('./package.json')
+import { dirname, join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import eslint from 'eslint'
 
-module.exports = {
-  bugs: pkg.bugs.url,
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const json = readFileSync('./package.json', 'utf8')
+const pkg = JSON.parse(json)
+const { bugs, homepage, version } = pkg
+
+export default {
+  bugs: bugs.url,
   cmd: 'standard',
   eslint,
   eslintConfig: {
-    configFile: path.join(__dirname, 'eslintrc.json')
+    configFile: join(__dirname, 'eslintrc.json')
   },
-  homepage: pkg.homepage,
+  homepage: homepage,
   tagline: 'Use JavaScript Standard Style',
-  version: pkg.version
+  version: version
 }

--- a/options.js
+++ b/options.js
@@ -1,7 +1,8 @@
-import { join } from 'node:path'
 import { readFileSync } from 'node:fs'
 import eslint from 'eslint'
 
+// eslintConfig.configFile have problem reading URLs and file:///
+const configFile = new URL('./eslintrc.json', import.meta.url).toString().slice(7)
 const pkgURL = new URL('./package.json', import.meta.url)
 const pkgJSON = readFileSync(pkgURL, { encoding: 'utf-8' })
 const pkg = JSON.parse(pkgJSON)
@@ -11,7 +12,7 @@ export default {
   cmd: 'standard',
   eslint,
   eslintConfig: {
-    configFile: join(__dirname, 'eslintrc.json')
+    configFile
   },
   homepage: pkg.homepage,
   tagline: 'Use JavaScript Standard Style',

--- a/options.js
+++ b/options.js
@@ -1,21 +1,19 @@
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import eslint from 'eslint'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const json = readFileSync('./package.json', 'utf8')
-const pkg = JSON.parse(json)
-const { bugs, homepage, version } = pkg
+const pkgURL = new URL('./package.json', import.meta.url)
+const pkgJSON = readFileSync(pkgURL, { encoding: 'utf-8' })
+const pkg = JSON.parse(pkgJSON)
 
 export default {
-  bugs: bugs.url,
+  bugs: pkg.bugs.url,
   cmd: 'standard',
   eslint,
   eslintConfig: {
     configFile: join(__dirname, 'eslintrc.json')
   },
-  homepage: homepage,
+  homepage: pkg.homepage,
   tagline: 'Use JavaScript Standard Style',
-  version: version
+  version: pkg.version
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tape": "^5.3.1"
   },
   "engines": {
-    "node": ">=12.20.0"
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "homepage": "https://standardjs.com",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "bin": {
     "standard": "bin/cmd.js"
   },
+  "type": "module",
   "bugs": {
     "url": "https://github.com/standard/standard/issues"
   },
@@ -33,7 +34,7 @@
     "tape": "^5.3.1"
   },
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=12.20.0"
   },
   "homepage": "https://standardjs.com",
   "keywords": [

--- a/test/api.js
+++ b/test/api.js
@@ -1,9 +1,9 @@
-const standard = require('../')
-const test = require('tape')
+import test from 'tape'
+import linter from '../index.js'
 
 test('api: lintFiles', t => {
   t.plan(3)
-  standard.lintFiles(['bin/cmd.js'], {}, (err, result) => {
+  linter.lintFiles(['bin/cmd.js'], {}, (err, result) => {
     t.error(err, 'no error while linting')
     t.equal(typeof result, 'object', 'result is an object')
     t.equal(result.errorCount, 0)
@@ -12,7 +12,7 @@ test('api: lintFiles', t => {
 
 test('api: lintText', t => {
   t.plan(3)
-  standard.lintText('console.log("hi there")\n', (err, result) => {
+  linter.lintText('console.log("hi there")\n', (err, result) => {
     t.error(err, 'no error while linting')
     t.equal(typeof result, 'object', 'result is an object')
     t.equal(result.errorCount, 1, 'should have used single quotes')

--- a/test/api.js
+++ b/test/api.js
@@ -1,9 +1,9 @@
 import test from 'tape'
-import linter from '../index.js'
+import standard from '../index.js'
 
 test('api: lintFiles', t => {
   t.plan(3)
-  linter.lintFiles(['bin/cmd.js'], {}, (err, result) => {
+  standard.lintFiles(['bin/cmd.js'], {}, (err, result) => {
     t.error(err, 'no error while linting')
     t.equal(typeof result, 'object', 'result is an object')
     t.equal(result.errorCount, 0)
@@ -12,7 +12,7 @@ test('api: lintFiles', t => {
 
 test('api: lintText', t => {
   t.plan(3)
-  linter.lintText('console.log("hi there")\n', (err, result) => {
+  standard.lintText('console.log("hi there")\n', (err, result) => {
     t.error(err, 'no error while linting')
     t.equal(typeof result, 'object', 'result is an object')
     t.equal(result.errorCount, 1, 'should have used single quotes')

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,7 +1,8 @@
+import { fileURLToPath } from 'node:url'
 import test from 'tape'
 import crossSpawn from 'cross-spawn'
 
-const CMD_PATH = new URL('../bin/cmd.js', import.meta.url).toString().slice(7)
+const CMD_PATH = fileURLToPath(new URL('../bin/cmd.js', import.meta.url))
 
 test('command line usage: --help', t => {
   t.plan(1)

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,11 +1,7 @@
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import test from 'tape'
 import crossSpawn from 'cross-spawn'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-const CMD_PATH = join(__dirname, '..', 'bin', 'cmd.js')
+const CMD_PATH = new URL('../bin/cmd.js', import.meta.url)
 
 test('command line usage: --help', t => {
   t.plan(1)

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,7 +1,7 @@
 import test from 'tape'
 import crossSpawn from 'cross-spawn'
 
-const CMD_PATH = new URL('../bin/cmd.js', import.meta.url)
+const CMD_PATH = new URL('../bin/cmd.js', import.meta.url).toString().slice(7)
 
 test('command line usage: --help', t => {
   t.plan(1)

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,8 +1,11 @@
-const path = require('path')
-const test = require('tape')
-const crossSpawn = require('cross-spawn')
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'tape'
+import crossSpawn from 'cross-spawn'
 
-const CMD_PATH = path.join(__dirname, '..', 'bin', 'cmd.js')
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const CMD_PATH = join(__dirname, '..', 'bin', 'cmd.js')
 
 test('command line usage: --help', t => {
   t.plan(1)

--- a/test/external/clone.js
+++ b/test/external/clone.js
@@ -7,23 +7,21 @@
  */
 
 import { cpus } from 'node:os'
+import { fileURLToPath } from 'node:url'
 import { readFileSync, mkdirSync, access, R_OK, W_OK, writeFileSync } from 'node:fs'
 import crossSpawn from 'cross-spawn'
 import minimist from 'minimist'
 import parallelLimit from 'run-parallel-limit'
 import test from 'tape'
 
-const getAbsolutePath = (path, pwd = import.meta.url) =>
-  new URL(path, pwd).toString().slice(7)
-
-const testJsonPath = getAbsolutePath('test.json')
+const testJsonPath = new URL('test.json', import.meta.url)
 const json = readFileSync(testJsonPath, 'utf8')
 const testPkgs = JSON.parse(json)
 
 const GIT = 'git'
 const NPM = 'npm'
-const STANDARD = getAbsolutePath('../../bin/cmd.js')
-const TMP = getAbsolutePath('../../tmp/')
+const STANDARD = fileURLToPath(new URL('../../bin/cmd.js', import.meta.url))
+const TMP = new URL('../../tmp/', import.meta.url)
 const PARALLEL_LIMIT = Math.ceil(cpus().length / 2)
 
 const argv = minimist(process.argv.slice(2), {
@@ -70,7 +68,7 @@ test('test github repos that use `standard`', t => {
   parallelLimit(pkgs.map(pkg => {
     const name = pkg.name
     const url = `${pkg.repo}.git`
-    const folder = new URL(name, `file://${TMP}`)
+    const folder = fileURLToPath(new URL(name, TMP))
     return cb => {
       access(folder, R_OK | W_OK, err => {
         if (argv.offline && err) {

--- a/tools/test-exists.js
+++ b/tools/test-exists.js
@@ -2,9 +2,9 @@
  * Sanity check that all repos in test.json actually exist on GitHub
  */
 
+import { readFileSync } from 'node:fs'
 import get from 'simple-get'
 import series from 'run-series'
-import { readFileSync } from 'fs'
 
 const testPkgs = JSON.parse(readFileSync('../test/test.json', 'utf8'))
 

--- a/tools/test-exists.js
+++ b/tools/test-exists.js
@@ -6,7 +6,7 @@ import { readFileSync } from 'node:fs'
 import get from 'simple-get'
 import series from 'run-series'
 
-const testPkgs = JSON.parse(readFileSync('../test/test.json', 'utf8'))
+const testPkgs = JSON.parse(readFileSync(new URL('../test/external/test.json', import.meta.url), 'utf8'))
 
 series(testPkgs.map(function (pkg) {
   return function (cb) {

--- a/tools/test-exists.js
+++ b/tools/test-exists.js
@@ -2,9 +2,11 @@
  * Sanity check that all repos in test.json actually exist on GitHub
  */
 
-const get = require('simple-get')
-const testPkgs = require('../test/test.json')
-const series = require('run-series')
+import get from 'simple-get'
+import series from 'run-series'
+import { readFileSync } from 'fs'
+
+const testPkgs = JSON.parse(readFileSync('../test/test.json', 'utf8'))
 
 series(testPkgs.map(function (pkg) {
   return function (cb) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

**What changes did you make? (Give an overview)**

- Switch from cjs to esm.
- bumped lowest supported node version

**Which issue (if any) does this pull request address?**

standard-engine is holding back on some esm stuff...

> it would offer a smoother transition to migrate to ESM only for packages like standard, ts-standard etc, before migrating this one (standard-engine). https://github.com/standard/standard-engine/issues/251#issuecomment-913229242

**Is there anything you'd like reviewers to focus on?**
