### PR TITLE
feat: support ESLint 8.X

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -12,19 +12,14 @@ jobs:
   test-external:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.22, 12, 14.17, 14, 16.0.0, 16]
-      fail-fast: false
-
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
 
       - name: Cache Node dependencies
         uses: actions/cache@v2

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['lts/*']
+        node-version: [12.22, 12, 14.17, 14, 16.0.0, 16]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-internal.yml
+++ b/.github/workflows/test-internal.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.20.0, 14.13.1, 16.0.0, 17]
+        node-version: [12.22, 12, 14.17, 14, 16.0.0, 16]
       fail-fast: false
 
     steps:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "eslint": "^8.7.0",
     "eslint-config-standard": "^17.0.0-0",
-    "eslint-config-standard-jsx": "^10.0.0",
+    "eslint-config-standard-jsx": "^11.0.0-0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-n": "^14.0.0",
     "eslint-plugin-promise": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/standard/standard/issues"
   },
   "dependencies": {
-    "eslint": "~7.18.0",
-    "eslint-config-standard": "16.0.3",
-    "eslint-config-standard-jsx": "10.0.0",
-    "eslint-plugin-import": "~2.25.3",
-    "eslint-plugin-node": "~11.1.0",
-    "eslint-plugin-promise": "~5.1.1",
-    "eslint-plugin-react": "~7.27.0",
+    "eslint": "^8.7.0",
+    "eslint-config-standard": "^17.0.0-0",
+    "eslint-config-standard-jsx": "^10.0.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-n": "^14.0.0",
+    "eslint-plugin-promise": "^6.0.0",
+    "eslint-plugin-react": "^7.28.0",
     "standard-engine": "^15.0.0-0"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
     "tape": "^5.3.2"
   },
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "homepage": "https://standardjs.com",
   "keywords": [


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

Dependencies should be compatible with ESLint 8 too before we can merge this one:

- [x] [`eslint-config-standard`](https://github.com/standard/eslint-config-standard) (https://github.com/standard/eslint-config-standard/issues/192)
  - [x] https://github.com/standard/eslint-config-standard/pull/193
  - [ ] `v17.0.0`
- [x] [`eslint-config-standard-jsx`](https://github.com/standard/eslint-config-standard-jsx) (https://github.com/standard/eslint-config-standard-jsx/issues/40)
  - [ ] https://github.com/standard/eslint-config-standard-jsx/pull/41
  - [ ] Release
- [x] [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import) (https://github.com/import-js/eslint-plugin-import/issues/2211)
  - [x] https://github.com/import-js/eslint-plugin-import/pull/2191
  - [x] [`v2.25.0`](https://github.com/import-js/eslint-plugin-import/releases/tag/v2.25.0)
- [x] [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node) (https://github.com/mysticatea/eslint-plugin-node/issues/294)
  - [ ] https://github.com/mysticatea/eslint-plugin-node/pull/224
  - [ ] https://github.com/mysticatea/eslint-plugin-node/pull/295
  - [ ] Release
- [x] [`eslint-plugin-promise`](https://github.com/xjamundx/eslint-plugin-promise) (https://github.com/xjamundx/eslint-plugin-promise/issues/218)
  - [x] https://github.com/xjamundx/eslint-plugin-promise/pull/219
  - [x] [`v6.0.0`](https://github.com/xjamundx/eslint-plugin-promise/blob/development/CHANGELOG.md#600)
- [x] [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react) (https://github.com/yannickcr/eslint-plugin-react/issues/3055)
  - [x] https://github.com/yannickcr/eslint-plugin-react/pull/3059
  - [x] [`v7.27.0`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#7270---20211109)
- [x] [`standard-engine`](https://github.com/standard/standard-engine) (https://github.com/standard/standard-engine/issues/234)
  - [x] https://github.com/standard/eslint-config-standard/pull/190
  - [ ] `v15.0.0`

---

BREAKING CHANGE: Requires Node@^12.22.0 || ^14.17.0 || >=16.0.0

Closes #1724