### PR TITLE
Start testing on latest 17

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.20.0, 14.13.1, 16.0.0]
+        node-version: [12.20.0, 14.13.1, 16.0.0, 17]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-internal.yml
+++ b/.github/workflows/test-internal.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.20.0, 14.13.1, 16.0.0]
+        node-version: [12.20.0, 14.13.1, 16.0.0, 17]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Even if Node.js `17.x` isn't going to be an LTS, we do support it and thus I think we should test it:

https://github.com/standard/standard/blob/7ab8604c31939900abc8f8f99c4a073189683fa5/package.json#L36-L38

This PR adds a new Node.js version to our tests, to trail the latest released Node.js version