### PR TITLE
Run external tests periodically

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  schedule:
+    - cron: '47 4 1/3 * *'
 
 jobs:
   test-external:


### PR DESCRIPTION
To ensure that we catch errors in external modules early.

This runs the tests every third day at 4:47. The time is randomly chosen as is best practice for cron jobs.

GitHub Actions schedule syntax: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule