### PR TITLE
Limit external runs to single Node version

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.20.0, 14.13.1, 16.0.0, 17]
+        node-version: ['lts/*']
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Picking `lts/*` to have it always run on the latest node.js LTS.

## Why?

Because it wastes less resources and linting should never differ between node.js versions for us, and if they are, then our internal tests will catch it.