### PR TITLE
Highlight errors rather than warnings on external CI

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -33,4 +33,4 @@ jobs:
         run: npm install
 
       - name: Run external tests
-        run: npm run test-external
+        run: npm run test-external-ci

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eslint-plugin-n": "^14.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.28.0",
-    "standard-engine": "^15.0.0-0"
+    "standard-engine": "^15.0.0-0",
+    "tap-github-actions": "^0.2.3"
   },
   "devDependencies": {
     "cross-spawn": "^7.0.3",
@@ -31,7 +32,7 @@
     "run-parallel-limit": "^1.1.0",
     "run-series": "^1.1.9",
     "simple-get": "^4.0.0",
-    "tape": "^5.3.2"
+    "tape": "^5.5.0"
   },
   "engines": {
     "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -72,6 +73,7 @@
     "test": "npm run test-internal && npm run test-external",
     "test-internal": "./bin/cmd.js --verbose && tape test/*.js",
     "test-external": "tape test/external/*.js",
+    "test-external-ci": "tape test/external/*.js | tap-github-actions",
     "update-authors": "./tools/update-authors.sh && hallmark --fix AUTHORS.md"
   },
   "funding": [

--- a/test/external/clone.js
+++ b/test/external/clone.js
@@ -22,7 +22,7 @@ const GIT = 'git'
 const NPM = 'npm'
 const STANDARD = fileURLToPath(new URL('../../bin/cmd.js', import.meta.url))
 const TMP = new URL('../../tmp/', import.meta.url)
-const PARALLEL_LIMIT = Math.ceil(cpus().length / 2)
+const PARALLEL_LIMIT = Math.max(2, cpus().length - 1)
 
 const argv = minimist(process.argv.slice(2), {
   boolean: [
@@ -62,6 +62,8 @@ if (!argv.disabled) {
 
 test('test github repos that use `standard`', outerT => {
   mkdirSync(TMP, { recursive: true })
+
+  outerT.comment(`Testing ${PARALLEL_LIMIT} repos in parallell`)
 
   parallelLimit(pkgs.map(pkg => {
     const name = pkg.name


### PR DESCRIPTION
A follow up to #1745 and #1744, purpose is to make it easier to spot which package it is that fails