### PR TITLE
build(dependabot): ignore non-major action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    ignore:
+      - dependency-name: "actions/*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
     schedule:
       interval: "daily"
     labels:

--- a/.github/workflows/old-test.yml
+++ b/.github/workflows/old-test.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/test-internal.yml
+++ b/.github/workflows/test-internal.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/test-internal.yml
+++ b/.github/workflows/test-internal.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.4.1
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

Improvement of maintenance setup

**What changes did you make? (Give an overview)**

Follow the lead of fastify/fastify#3451

No need to add the PR noise of every little patch or minor update to official GitHub actions. That just creates alert fatigue and drowns out actually substantial and/or important PR:s.

**Which issue (if any) does this pull request address?**

Solves fastify/fastify#3451, but for `standard/standard`

**Is there anything you'd like reviewers to focus on?**

Whether there are any objections to this change (and whether I have forgotten to widen an action range somewhere)