### PR TITLE
Improve pre-commit hook and docs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,6 @@
 - id: standard
   name: standard
+  description: JavaScript style guide, linter, and formatter
   entry: standard --fix
   language: node
   files: "\\.(\

--- a/README.md
+++ b/README.md
@@ -692,9 +692,11 @@ fi
 
 ### Use a `pre-commit` hook
 
-The [pre-commit](https://pre-commit.com/) library allows hooks to be declared within a `.pre-commit-config.yaml` configuration file in the repo, and therefore more easily maintained across a team.
+The [pre-commit](https://pre-commit.com/) framework allows hooks to be declared within a `.pre-commit-config.yaml` configuration file in the repo, and therefore more easily maintained across a team.
+It handles installing and running Standard JS on all JavaScript files.
 
 Users of pre-commit can simply add `standard` to their `.pre-commit-config.yaml` file, which will automatically fix `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs` and `.cjs` files:
+
 ```yaml
   - repo: https://github.com/standard/standard
     rev: master
@@ -702,7 +704,10 @@ Users of pre-commit can simply add `standard` to their `.pre-commit-config.yaml`
       - id: standard
 ```
 
+After adding this configuration, run `pre-commit autoupdate --repo https://github.com/standard/standard` to pin to the latest version.
+
 Alternatively, for more advanced styling configurations, use `standard` within the [eslint hook](https://github.com/pre-commit/mirrors-eslint):
+
 ```yaml
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: master


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

**What changes did you make? (Give an overview)**

* Add the `description` field that will appear on https://pre-commit.com/hooks.html (I’m about to submit it).
* Describe what pre-commit does a little more.
* Describe the `pre-commit autoupdate` step required to pin to a specific version rather than `master`. Using `master` could be broken, and isn't reproducible between environments. Indeed pre-commit warns if you use `master`:

  ```
  [WARNING] The 'rev' field of repo 'https://github.com/standard/standard' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
  ```

**Which issue (if any) does this pull request address?**

No issue.

**Is there anything you'd like reviewers to focus on?**

Nope.