### PR TITLE
Increase `daysUntilClose` for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,7 +4,7 @@
 daysUntilStale: 180
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 60
 
 # Issues with these labels will never be considered stale
 exemptLabels:


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

Make stale bot a bit less aggressive for now

**What changes did you make? (Give an overview)**

Changed from 14 days between comment and close to 60 days

**Which issue (if any) does this pull request address?**

Gives us all more time to act on things

**Is there anything you'd like reviewers to focus on?**

Just whether we want this change or not