### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/old-test.yml
+++ b/.github/workflows/old-test.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '47 4 1/3 * *'
 
+permissions:
+  contents: read
+
 jobs:
   test-external:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-internal.yml
+++ b/.github/workflows/test-internal.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test-internal:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
