### PR TITLE
docs(rules): fix markdown formatting issue

### DIFF
--- a/docs/RULES-esla.md
+++ b/docs/RULES-esla.md
@@ -203,8 +203,8 @@ La mejor manera de aprender acerca de `standard` es instalarlo darle una prueba 
   ```js
   // ✗ evitar
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-fr.md
+++ b/docs/RULES-fr.md
@@ -213,8 +213,8 @@ La meilleure façon d'apprendre plus sur `standard` c'est de l'installer et de l
   ```js
   // ✗ avoid
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-id.md
+++ b/docs/RULES-id.md
@@ -219,8 +219,8 @@ Cara terbaik untuk belajar tentang `standard` adalah dengan memasangnya pada pro
   ```js
   // ✗ hindari
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-iteu.md
+++ b/docs/RULES-iteu.md
@@ -202,8 +202,8 @@ Il modo migliore per imparare `standard` è quello di installarlo e provarlo sul
   ```js
   // ✗ evita
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-ja.md
+++ b/docs/RULES-ja.md
@@ -217,8 +217,8 @@
   ```js
   // ✗ avoid
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-kokr.md
+++ b/docs/RULES-kokr.md
@@ -203,8 +203,8 @@
   ```js
   // ✗ 피하세요
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-ptbr.md
+++ b/docs/RULES-ptbr.md
@@ -179,8 +179,8 @@ A melhor forma de aprender sobre o `standard` é instalar e usar no seu código.
   ```js
   // ✗ evite
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-zhcn.md
+++ b/docs/RULES-zhcn.md
@@ -205,8 +205,8 @@
   ```js
   // ✗ avoid
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 

--- a/docs/RULES-zhtw.md
+++ b/docs/RULES-zhtw.md
@@ -203,8 +203,8 @@
   ```js
   // ✗ avoid
   var value = 'hello world'
-
-
+  
+  
   console.log(value)
   ```
 * **三元運算子（ternary operator）** 在多行的情況下，把 `?` 和 `:` 和後面敘述放在同一行。


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

In `no-multiple-empty-lines` part, I added an indent at the position of the blank line. This will fix the error as shown in the picture below on the left (a single block of code is incorrectly parsed into two parts, and the next section is incorrectly wrapped into the code block).

![Screenshot](https://user-images.githubusercontent.com/1998168/170216115-2ee14077-81a1-4c65-a2b9-db37cd23dc21.png)

Link: https://standardjs.com/rules-zhcn.html and other languages.

Reason: This code block is located in an unordered list, so it should retain indentation, otherwise it would terminate the list.

Notes: `RULES.md` has already be fixed in https://github.com/standard/standard/commit/c4fa50760698e61b6aa24e988a4e3fbf001210ee, but I think adding indent is the less modified option.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
