### PR TITLE
Fixed comparison at `bin/cmd`

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -5,7 +5,7 @@ var match = process.version.match(/v(\d+)\.(\d+)/)
 var major = parseInt(match[1], 10)
 var minor = parseInt(match[2], 10)
 
-if (major >= 12 || (major === 12 && minor >= 20)) {
+if (major > 12 || (major === 12 && minor >= 20)) {
   eval('import("standard-engine")').then(function (standardEngine) {
     eval('import("../options.js")').then(function (options) {
       standardEngine.cli(options.default)


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Changed a comparison within an expression to what it seemed correct. The expression after the `||` tested for equality, but the `>=` op already did that, so I changed it to allow `===` to be useful

**Which issue (if any) does this pull request address?**
None. I searched and didn't find anything similar

**Is there anything you'd like reviewers to focus on?**