### PR TITLE
feat: move standard to node native test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
   },
   "scripts": {
     "test": "npm run test-internal && npm run test-external",
-    "test-internal": "./bin/cmd.cjs --verbose && tape test/*.js",
-    "test-external": "tape test/external/*.js",
+    "test-internal": "./bin/cmd.cjs --verbose && node --test test/*.js",
+    "test-external": "node --test test/external/*.js",
     "update-authors": "./tools/update-authors.sh && hallmark --fix AUTHORS.md"
   },
   "funding": [

--- a/test/api.js
+++ b/test/api.js
@@ -1,16 +1,16 @@
-import test from 'tape'
+import assert from 'node:assert'
+import test from 'node:test'
 import standard from '../index.js'
 
 test('api: lintFiles', async (t) => {
-  t.plan(2)
-  const [result] = await standard.lintFiles(['bin/cmd.cjs'])
-  t.equal(typeof result, 'object', 'result is an object')
-  t.equal(result.errorCount, 0)
+  // The node process calling this is at the root level
+  const [result] = await standard.lintFiles('./bin/cmd.cjs')
+  assert.equal(typeof result, 'object', 'result is an object')
+  assert.equal(result.errorCount, 0)
 })
 
 test('api: lintText', async (t) => {
-  t.plan(2)
   const [result] = await standard.lintText('console.log("hi there")\n')
-  t.equal(typeof result, 'object', 'result is an object')
-  t.equal(result.errorCount, 1, 'should have used single quotes')
+  assert.equal(typeof result, 'object', 'result is an object')
+  assert.equal(result.errorCount, 1, 'should have used single quotes')
 })

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,17 +1,16 @@
 import { fileURLToPath } from 'node:url'
-import test from 'tape'
+import assert from 'node:assert'
+import test from 'node:test'
 import crossSpawn from 'cross-spawn'
 
 const CMD_PATH = fileURLToPath(new URL('../bin/cmd.cjs', import.meta.url))
 
 test('command line usage: --help', t => {
-  t.plan(1)
-
   const child = crossSpawn(CMD_PATH, ['--help'])
   child.on('error', err => {
-    t.fail(err)
+    assert.fail(err)
   })
   child.on('close', code => {
-    t.equal(code, 0, 'zero exit code')
+    assert.equal(code, 0, 'zero exit code')
   })
 })

--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -1,16 +1,15 @@
-import test from 'tape'
+import test from 'node:test'
+import assert from 'node:assert'
 import standard from '../index.js'
 
 test('load config in eslint to validate all rule syntax is correct', async function (t) {
-  t.plan(1)
   const code = 'const foo = 1\nconst bar = function () {}\nbar(foo)\n'
   const [result] = await standard.lintText(code)
-  t.equal(result.errorCount, 0)
+  assert.equal(result.errorCount, 0)
 })
 
 test('ensure we allow top level await', async function (t) {
-  t.plan(1)
   const code = 'const foo = await 1\nconst bar = function () {}\nawait bar(foo)\n'
   const [result] = await standard.lintText(code)
-  t.equal(result.errorCount, 0)
+  assert.equal(result.errorCount, 0)
 })


### PR DESCRIPTION
In relation to https://github.com/standard/standard-engine/issues/277 I wanted to test out the node native test runner on [standard](https://github.com/standard/standard). Open to thoughts/opinions. @voxpelli you opened that original issue, your opinion would be appreciated. I have been poking at testing it on [standard-engine](https://github.com/standard/standard-engine) as well.